### PR TITLE
build: grpc 1.79.0 LTS alignment (NATIVE-001 Option A) + Netty 4.1.135 CVE wave + native/io_uring docs

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -370,26 +370,24 @@ agents read the same section. Consumer-proven 2026-06 on 8 downstream Quarkus
 are framework defects with roadmap items: apply the workaround now, delete it
 when the item completes.
 
-### 13.1 io.grpc version skew — native build aborts [gap → NATIVE-001]
+### 13.1 io.grpc version alignment — Quarkus LTS support matrix
 
-krpc pins `grpcVersion=1.82.0` (`gradle.properties:14`) and exports it
-transitively. Gradle resolves highest-wins, so in a Quarkus app krpc's 1.82.0
-overrides the Quarkus BOM's io.grpc (1.79.0 on Quarkus 3.33.2). JVM mode
-tolerates the skew; native-image does not — Quarkus's GraalVM substitution
-`Target_io_grpc_ServiceProviders.loadAll` no longer matches the 1.82.0 class
-shape and native-image **aborts during Initializing**. Wire behavior is not
-affected; this is a build-time class-shape conflict only.
+krpc tracks the Quarkus LTS BOM's io.grpc version (Option A, ADR NATIVE-001).
+`gradle.properties` pins `grpcVersion` to what the supported Quarkus LTS ships, so
+a Quarkus consumer's highest-wins resolution converges on a single io.grpc — no
+consumer-side force, and native-image's `Target_io_grpc_ServiceProviders`
+substitution matches the class shape.
 
-Consumer workaround — force ALL `io.grpc:*` back to the BOM version in the root
-build (single point, covers every service):
+| krpc release       | Quarkus LTS | io.grpc | consumer force |
+|--------------------|-------------|---------|----------------|
+| > 1.0.2 (current)  | 3.33.x LTS  | 1.79.0  | none — aligned |
+| ≤ 1.0.2            | 3.33.x LTS  | 1.82.0  | required (below) |
 
-```groovy
-configurations.all {
-    resolutionStrategy.eachDependency { d ->
-        if (d.requested.group == 'io.grpc') { d.useVersion '1.79.0' } // = Quarkus BOM version
-    }
-}
-```
+Bump `grpcVersion` in lockstep when adopting the next Quarkus LTS.
+
+**For krpc ≤1.0.2 only** (ships io.grpc 1.82.0, skewed above the BOM → native-image
+aborts during Initializing): force `io.grpc:*` back to the BOM version in the root
+build — `configurations.all { resolutionStrategy.eachDependency { if (it.requested.group == 'io.grpc') it.useVersion '1.79.0' } }`.
 
 ### 13.2 Server-side gRPC provider not registered [gap → NATIVE-002]
 
@@ -416,6 +414,9 @@ one build flag:
    ServiceLoader can instantiate them.
 3. `compileOnly "org.graalvm.sdk:nativeimage"` (Feature API is build-time only).
 
+**Fixed in `ext-rpc` >1.0.1 (NATIVE-002, unreleased).** Still required for published
+`ext-rpc` ≤1.0.1; delete this workaround once the fixed ext-rpc ships.
+
 ### 13.3 Stale ext-rpc substitutions collide with Quarkus [gap → NATIVE-002]
 
 `tech.krpc.ext:ext-rpc` ships its own grpc-netty GraalVM substitution classes
@@ -427,6 +428,9 @@ authoritative and the duplicates abort the build. Strip them in
 ```properties
 quarkus.class-loading.removed-resources."tech.krpc.ext\:ext-rpc"=tech/krpc/ext/runtime/graal/Target_io_grpc_netty_Utils.class,tech/krpc/ext/runtime/graal/GrpcNettySubstitutions.class
 ```
+
+**Fixed in `ext-rpc` >1.0.1 (NATIVE-002, unreleased).** Still required for published
+`ext-rpc` ≤1.0.1; delete this workaround once the fixed ext-rpc ships.
 
 ### 13.4 Build recipe and known runtime issues
 
@@ -483,9 +487,9 @@ only for what its build-time scan can reach. Know what is and is not covered.
 
 ### 13.6 Native checklist for a consumer service
 
-- [ ] `io.grpc:*` forced to the Quarkus BOM version (root build) — §13.1.
-- [ ] ServerProvider Feature + provider reflection holder + `compileOnly nativeimage` — §13.2.
-- [ ] ext-rpc stale substitutions stripped via `removed-resources` — §13.3.
+- [ ] **krpc ≤1.0.2 only:** `io.grpc:*` forced to the Quarkus BOM version (root build) — §13.1. (krpc >1.0.2 is aligned; skip.)
+- [ ] **ext-rpc ≤1.0.1 only:** ServerProvider Feature + provider reflection holder + `compileOnly nativeimage` — §13.2.
+- [ ] **ext-rpc ≤1.0.1 only:** ext-rpc stale substitutions stripped via `removed-resources` — §13.3.
 - [ ] Builder image matches Quarkus/JDK line; `package.jar.enabled=false` — §13.4.
 - [ ] Per-service `--initialize-at-run-time` for static-heap violations — §13.4.
 - [ ] Datasource config present at runtime (SIGSEGV otherwise) — §13.4.

--- a/SPEC.md
+++ b/SPEC.md
@@ -448,7 +448,27 @@ quarkus.class-loading.removed-resources."tech.krpc.ext\:ext-rpc"=tech/krpc/ext/r
   is absent** (logs "started", then exit 139). Ensure `QUARKUS_DATASOURCE_*` is
   set; JVM mode fails gracefully, native does not.
 
-### 13.5 Reflection coverage (what the framework registers for you)
+### 13.5 io_uring transport (evaluated 2026-07)
+
+Status: evaluated. A flag-gated PoC exists on eval branch `feat/iouring-eval` —
+**not shipped; the default transport stays NIO in native / epoll-or-NIO on JVM.**
+
+- **Netty artifact constraint.** Today's stack (Quarkus 3.33 LTS = Netty 4.1) can
+  only use the ARCHIVED incubator artifact
+  (`io.netty.incubator:netty-incubator-transport-native-io_uring:0.0.26.Final`).
+  The graduated transport (`io.netty.channel.uring`) is Netty-4.2-only, which
+  arrives with Quarkus 4 / Vert.x 5.
+- **Native-image: works.** Flag `KRPC_IOURING`, hand-authored JNI/reflect/resource
+  metadata, `--initialize-at-run-time`; +0.56 MiB image, +1.9 MiB RSS.
+- **Benchmark verdict (aarch64, containerized): 5–6% SLOWER than NIO** on krpc's
+  typical small-message unary path. io_uring's win case (many connections,
+  syscall-bound) is not this profile. Details:
+  workspace `docs/orchestration/IOURING-001_{RESEARCH,BENCH}_omp.md`.
+- **Ops note.** Docker's default seccomp profile blocks io_uring syscalls
+  (`io_uring_setup` → EPERM); running the flag ON in containers needs an allowing
+  seccomp profile.
+
+### 13.6 Reflection coverage (what the framework registers for you)
 
 Native is closed-world: the framework registers reflection at build time, but
 only for what its build-time scan can reach. Know what is and is not covered.
@@ -487,7 +507,7 @@ only for what its build-time scan can reach. Know what is and is not covered.
   `rpc-server-quarkus/src/main/resources/META-INF/native-image/rpc-server/...`).
   You only own the third-party types your DTOs pull in.
 
-### 13.6 Native checklist for a consumer service
+### 13.7 Native checklist for a consumer service
 
 - [ ] **krpc ≤1.0.2 only:** `io.grpc:*` forced to the Quarkus BOM version (root build) — §13.1. (krpc >1.0.2 is aligned; skip.)
 - [ ] **ext-rpc ≤1.0.1 only:** ServerProvider Feature + provider reflection holder + `compileOnly nativeimage` — §13.2.
@@ -495,7 +515,7 @@ only for what its build-time scan can reach. Know what is and is not covered.
 - [ ] Builder image matches Quarkus/JDK line; `package.jar.enabled=false` — §13.4.
 - [ ] Per-service `--initialize-at-run-time` for static-heap violations — §13.4.
 - [ ] Datasource config present at runtime (SIGSEGV otherwise) — §13.4.
-- [ ] `ext-rpc` / `ext-mybatis` extensions on the build (DTO reflection) — §13.5.
+- [ ] `ext-rpc` / `ext-mybatis` extensions on the build (DTO reflection) — §13.6.
 
 ---
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -362,11 +362,90 @@ GitHub release after Central publish succeeds.
 
 ---
 
-## 13. Native image (GraalVM) reflection
+## 13. Native image (GraalVM)
 
-Use the native build command in [§12](#12-build-test-release). Native is closed-world:
-the framework registers reflection at build time, but only for what its build-time
-scan can reach. Know what is and is not covered.
+Single source of truth for building krpc services as native images — humans and
+agents read the same section. Consumer-proven 2026-06 on 8 downstream Quarkus
+3.33.2 services (boot-to-ready 0.028s native). Items tagged `[gap → NATIVE-00x]`
+are framework defects with roadmap items: apply the workaround now, delete it
+when the item completes.
+
+### 13.1 io.grpc version skew — native build aborts [gap → NATIVE-001]
+
+krpc pins `grpcVersion=1.82.0` (`gradle.properties:14`) and exports it
+transitively. Gradle resolves highest-wins, so in a Quarkus app krpc's 1.82.0
+overrides the Quarkus BOM's io.grpc (1.79.0 on Quarkus 3.33.2). JVM mode
+tolerates the skew; native-image does not — Quarkus's GraalVM substitution
+`Target_io_grpc_ServiceProviders.loadAll` no longer matches the 1.82.0 class
+shape and native-image **aborts during Initializing**. Wire behavior is not
+affected; this is a build-time class-shape conflict only.
+
+Consumer workaround — force ALL `io.grpc:*` back to the BOM version in the root
+build (single point, covers every service):
+
+```groovy
+configurations.all {
+    resolutionStrategy.eachDependency { d ->
+        if (d.requested.group == 'io.grpc') { d.useVersion '1.79.0' } // = Quarkus BOM version
+    }
+}
+```
+
+### 13.2 Server-side gRPC provider not registered [gap → NATIVE-002]
+
+krpc talks to io.grpc directly (not via quarkus-grpc), and Quarkus builds native
+images with `-H:-UseServiceLoaderFeature` — so grpc's `ServiceLoader` lookups
+find nothing unless someone registers the providers. krpc only covers the
+CLIENT side: `rpc-client/.../ext/GraalvmBuild.java:14-18` build-time-initializes
+`ManagedChannelProvider` / `NameResolverRegistry` / `LoadBalancerRegistry`. The
+server-side counterpart (`rpc-server-quarkus/.../GraalvmBuild.java`) is entirely
+commented out, so `io.grpc.ServerRegistry` is empty in the image and the native
+server dies at boot with
+`ManagedChannelProvider$ProviderNotFoundException: No functional server found`.
+
+Consumer workaround (per service, proven on 8 services) — two small classes +
+one build flag:
+
+1. A GraalVM `Feature` whose `beforeAnalysis` calls `io.grpc.ServerProvider.provider()`
+   (bakes the server provider list into the image heap), wired via
+   `quarkus.native.additional-build-args=--features=<pkg>.NettyServerProviderFeature`.
+2. An `@RegisterForReflection(classNames = {"io.grpc.netty.NettyServerProvider",
+   "io.grpc.netty.NettyChannelProvider", "io.grpc.netty.UdsNettyChannelProvider",
+   "io.grpc.internal.PickFirstLoadBalancerProvider",
+   "io.grpc.internal.DnsNameResolverProvider"})` holder so grpc's runtime
+   ServiceLoader can instantiate them.
+3. `compileOnly "org.graalvm.sdk:nativeimage"` (Feature API is build-time only).
+
+### 13.3 Stale ext-rpc substitutions collide with Quarkus [gap → NATIVE-002]
+
+`tech.krpc.ext:ext-rpc` ships its own grpc-netty GraalVM substitution classes
+(`tech/krpc/ext/runtime/graal/Target_io_grpc_netty_Utils`,
+`.../GrpcNettySubstitutions`). In a Quarkus app, Quarkus's substitutions are
+authoritative and the duplicates abort the build. Strip them in
+`application.properties`:
+
+```properties
+quarkus.class-loading.removed-resources."tech.krpc.ext\:ext-rpc"=tech/krpc/ext/runtime/graal/Target_io_grpc_netty_Utils.class,tech/krpc/ext/runtime/graal/GrpcNettySubstitutions.class
+```
+
+### 13.4 Build recipe and known runtime issues
+
+- Build command: [§12](#12-build-test-release). Native needs
+  `-Dquarkus.package.jar.enabled=false` (Gradle can't output both), and the
+  builder image must match your Quarkus/JDK line — for the JDK 21 baseline use
+  `quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:jdk-21` (krpc's own
+  test-server was additionally validated on Mandrel 25 / jdk-25).
+- Static-heap violations are per-service: any `static final` SecureRandom /
+  Random / network-touching singleton fails analysis; fix with
+  `--initialize-at-run-time=<class>` (the native build error names the class).
+- Known issue: a native runner **SIGSEGVs at startup when datasource env/config
+  is absent** (logs "started", then exit 139). Ensure `QUARKUS_DATASOURCE_*` is
+  set; JVM mode fails gracefully, native does not.
+
+### 13.5 Reflection coverage (what the framework registers for you)
+
+Native is closed-world: the framework registers reflection at build time, but
+only for what its build-time scan can reach. Know what is and is not covered.
 
 - **The extensions must be on the native build.** DTO reflection is registered by
   the `ext-rpc` Quarkus deployment processor: it indexes every `@RpcService`
@@ -401,6 +480,16 @@ scan can reach. Know what is and is not covered.
   (`rpc-api/...`, `rpc-common/...`, `rpc-client/...`,
   `rpc-server-quarkus/src/main/resources/META-INF/native-image/rpc-server/...`).
   You only own the third-party types your DTOs pull in.
+
+### 13.6 Native checklist for a consumer service
+
+- [ ] `io.grpc:*` forced to the Quarkus BOM version (root build) — §13.1.
+- [ ] ServerProvider Feature + provider reflection holder + `compileOnly nativeimage` — §13.2.
+- [ ] ext-rpc stale substitutions stripped via `removed-resources` — §13.3.
+- [ ] Builder image matches Quarkus/JDK line; `package.jar.enabled=false` — §13.4.
+- [ ] Per-service `--initialize-at-run-time` for static-heap violations — §13.4.
+- [ ] Datasource config present at runtime (SIGSEGV otherwise) — §13.4.
+- [ ] `ext-rpc` / `ext-mybatis` extensions on the build (DTO reflection) — §13.5.
 
 ---
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -378,14 +378,16 @@ a Quarkus consumer's highest-wins resolution converges on a single io.grpc — n
 consumer-side force, and native-image's `Target_io_grpc_ServiceProviders`
 substitution matches the class shape.
 
-| krpc release       | Quarkus LTS | io.grpc | consumer force |
-|--------------------|-------------|---------|----------------|
-| > 1.0.2 (current)  | 3.33.x LTS  | 1.79.0  | none — aligned |
-| ≤ 1.0.2            | 3.33.x LTS  | 1.82.0  | required (below) |
+| krpc release                    | Quarkus LTS | io.grpc | consumer force |
+|---------------------------------|-------------|---------|----------------|
+| next release (this alignment)   | 3.33.x LTS  | 1.79.0  | none — aligned |
+| published ≤ 1.0.2               | 3.33.x LTS  | 1.82.0  | required (below) |
 
-Bump `grpcVersion` in lockstep when adopting the next Quarkus LTS.
+(HEAD is still tagged `1.0.2` in `gradle.properties` but already carries the 1.79.0
+alignment; it publishes as the next version bump. Bump `grpcVersion` in lockstep when
+adopting the next Quarkus LTS.)
 
-**For krpc ≤1.0.2 only** (ships io.grpc 1.82.0, skewed above the BOM → native-image
+**For published krpc ≤1.0.2 only** (ships io.grpc 1.82.0, skewed above the BOM → native-image
 aborts during Initializing): force `io.grpc:*` back to the BOM version in the root
 build — `configurations.all { resolutionStrategy.eachDependency { if (it.requested.group == 'io.grpc') it.useVersion '1.79.0' } }`.
 

--- a/build.gradle
+++ b/build.gradle
@@ -49,13 +49,23 @@ subprojects {
         options.compilerArgs << '-parameters'
     }
 
-    // IOURING-001 Phase 1 CVE wave: import the Netty BOM at nettyGrpcVersion so EVERY io.netty:*
-    // (incl. transitive-only netty-codec-http2 / -socks / handler-proxy, which no module declares
-    // directly) converges on one version. Highest-wins beats the Quarkus BOM's non-strict 4.1.133
-    // constraint => lifts codec-http2 (both hot-path HTTP/2 CVEs) to 4.1.135 and preserves the
-    // single-Netty convergence invariant (c433f3f). Constraint-only; adds no dependency.
-    dependencies {
-        implementation platform("io.netty:netty-bom:$nettyGrpcVersion")
+    // IOURING-001 Phase 1 CVE wave: converge EVERY io.netty:* (incl. transitive-only
+    // netty-codec-http2 / -socks / handler-proxy, which no module declares directly) on
+    // nettyGrpcVersion so the CVE-fixed 4.1.135 reaches codec-http2 (both hot-path HTTP/2 CVEs)
+    // and the single-Netty convergence invariant (c433f3f) holds.
+    //
+    // BUILD-LOCAL ONLY (do NOT import io.netty:netty-bom as a platform): a published platform
+    // import leaks into every module's POM <dependencyManagement> + GMM endorseStrictVersions,
+    // which would suppress a downstream consumer's own BOM. resolutionStrategy.eachDependency runs
+    // at resolution time and is NEVER written to the POM/GMM, so consumers keep BOM precedence
+    // while krpc's own build (JVM + native) still converges on 4.1.135.
+    configurations.all {
+        resolutionStrategy.eachDependency { details ->
+            if (details.requested.group == 'io.netty') {
+                details.useVersion "$nettyGrpcVersion"
+                details.because 'IOURING-001 CVE wave: single-Netty convergence to 4.1.135 (build-local, not published)'
+            }
+        }
     }
 
     plugins.withId('org.kordamp.gradle.jandex') {

--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,15 @@ subprojects {
         options.compilerArgs << '-parameters'
     }
 
+    // IOURING-001 Phase 1 CVE wave: import the Netty BOM at nettyGrpcVersion so EVERY io.netty:*
+    // (incl. transitive-only netty-codec-http2 / -socks / handler-proxy, which no module declares
+    // directly) converges on one version. Highest-wins beats the Quarkus BOM's non-strict 4.1.133
+    // constraint => lifts codec-http2 (both hot-path HTTP/2 CVEs) to 4.1.135 and preserves the
+    // single-Netty convergence invariant (c433f3f). Constraint-only; adds no dependency.
+    dependencies {
+        implementation platform("io.netty:netty-bom:$nettyGrpcVersion")
+    }
+
     plugins.withId('org.kordamp.gradle.jandex') {
         tasks.named('javadoc') {
             dependsOn(tasks.named('jandex'))

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -19,6 +19,11 @@ This index maps the repository source of truth for KRPC.
 
 - [Active Roadmap](roadmap/active-roadmap.md)
 
+## Handbook
+
+- [Development Spec](../SPEC.md) — authoring handbook for humans and coding
+  agents (method contract, errors, auth, native image §13)
+
 ## Plans
 
 - [Dependency Bump Plan](plan/2026-05-30-dependency-bump.md)
@@ -36,3 +41,4 @@ This index maps the repository source of truth for KRPC.
 | Framework, native-image, gateway, and tooling integrations | `rpc-client-spring`, `rpc-server-spring`, `rpc-server-quarkus`, `http-server`, `rpcurl`, `test-rpc-gen` | ADR-0001 | GOV-001 |
 | JDK 21 baseline and virtual-thread runtime feature | `rpc-server`, `rpc-client`, `http-server`, integration modules | ADR-0002 | N/A |
 | Agent-friendly introspection (HTTP discover→call, runtime MCP surface) | `rpc-common`, `rpc-server`, `rpc-client`, `http-server`, `rpc-api` | ADR-0004 | AGENT-001 |
+| Quarkus native-image consumer path (grpc alignment, provider registration) | `gradle.properties`, `rpc-server-quarkus`, `SPEC.md` §13 (+ `ext-rpc`, workspace NATIVE-002) | N/A | NATIVE-001 |

--- a/docs/modules/platform-integrations.md
+++ b/docs/modules/platform-integrations.md
@@ -31,6 +31,7 @@
 
 - Document integration ownership so framework support does not drift into core runtime modules. Status: active
 - Keep Spring, Quarkus, GraalVM native-image, HTTP gateway, and test/demo behavior aligned with the JDK 21 baseline. Status: active
+- Close the native-image consumer gaps found downstream 2026-06: grpc version alignment (NATIVE-001, krpc roadmap) and server-side provider registration upstreamed into ext-rpc (NATIVE-002, workspace roadmap). Consumer-facing truth: `SPEC.md` §13. Status: active
 
 ### Deferred / Obsolete
 

--- a/docs/roadmap/active-roadmap.md
+++ b/docs/roadmap/active-roadmap.md
@@ -1,5 +1,34 @@
 # Active Roadmap
 
+## NATIVE-001: io.grpc Version Alignment For Quarkus Native Consumers
+
+Status: active
+
+Capability: krpc artifacts consumable in Quarkus native builds without a
+consumer-side grpc version force
+
+Components:
+
+- `gradle.properties` (`grpcVersion=1.82.0`)
+- published POM dependency metadata (`tech.krpc:*`)
+- `SPEC.md` §13.1 (consumer workaround — delete when this completes)
+
+ADR: N/A (evidence: downstream native builds abort during Initializing —
+Quarkus GraalVM substitution `Target_io_grpc_ServiceProviders.loadAll` does not
+match grpc 1.82.0 when krpc's transitive pin overrides the Quarkus BOM's 1.79.0;
+verified 2026-06 on 8 downstream Quarkus 3.33.2 services)
+
+Acceptance Criteria:
+
+- A documented grpc version policy: either align `grpcVersion` with the current
+  Quarkus LTS BOM, or declare the supported Quarkus↔krpc↔grpc matrix and mark
+  `io.grpc:*` so the consumer BOM wins by default (e.g. compatible-range /
+  runtime-provided scope), with the tradeoff recorded.
+- A Quarkus 3.33.x consumer can native-build without a root-build
+  `resolutionStrategy` force on `io.grpc:*`.
+- Wire compatibility across the supported grpc range is stated in `SPEC.md`.
+- `SPEC.md` §13.1 workaround section removed.
+
 ## GOV-001: Establish Repository Governance Baseline
 
 Status: active

--- a/docs/roadmap/active-roadmap.md
+++ b/docs/roadmap/active-roadmap.md
@@ -29,6 +29,34 @@ Acceptance Criteria:
 - Wire compatibility across the supported grpc range is stated in `SPEC.md`.
 - `SPEC.md` §13.1 workaround section removed.
 
+## NATIVE-003: io_uring transport revisit
+
+Status: deferred
+
+Capability: adopt Netty's io_uring transport for krpc's native server if and when
+it outperforms NIO on a representative workload
+
+Components:
+
+- `rpc-server` (`IoUringTransport`, `KRPC_IOURING` flag), native metadata
+  (`test-server-iouring` reflect/jni/resource configs)
+- `SPEC.md` §13.5 (evaluation note)
+- eval branch `feat/iouring-eval` (flag-gated PoC)
+
+ADR: N/A (evidence: 2026-07 PoC benchmarked 5–6% SLOWER than NIO on krpc's
+small-message unary path, aarch64 containerized — workspace
+`docs/orchestration/IOURING-001_{RESEARCH,BENCH}_omp.md`)
+
+Gated on: Quarkus 4 / Vert.x 5 (Netty 4.2 graduated `io.netty.channel.uring`
+transport with in-jar native metadata — removes the archived-incubator artifact
+and hand-authored metadata this PoC required).
+
+Acceptance Criteria:
+
+- Re-benchmark on a high-connection-count / streaming workload (io_uring's
+  syscall-bound win case), not the small-message unary path.
+- Adopt only if it wins there; the flag stays default OFF regardless.
+
 ## GOV-001: Establish Repository Governance Baseline
 
 Status: active

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,9 @@ jandexVersion=2.3.0
 #https://github.com/grpc/grpc-java/blob/v1.46.x/build.gradle#L58
 # grpc pkg
 #grpcVersion=1.77.0
-grpcVersion=1.82.0
+# ADR NATIVE-001 (Option A, 2026-07-02): align to Quarkus LTS BOM (3.33.2 → io.grpc 1.79.0).
+# krpc uses zero API introduced after 1.79; single-Netty convergence (c433f3f) is grpc-version-independent.
+grpcVersion=1.79.0
 #https://github.com/protocolbuffers/protobuf/tree/main/java
 #https://mvnrepository.com/artifact/io.grpc/grpc-protobuf/1.48.0
 #protobufVersion=3.25.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -27,7 +27,11 @@ grpcVersion=1.79.0
 # https://central.sonatype.com/artifact/io.grpc/grpc-netty/dependencies
 
 #nettyGrpcVersion=4.1.127.Final
-nettyGrpcVersion=4.1.133.Final
+# IOURING-001 Phase 1 CVE wave: 4.1.133 -> 4.1.135.Final. 4.1.135 is the only post-4.1.133
+# 4.1.x with security content; fixes hot-path HTTP/2 DoS CVE-2026-47244 (MAX_CONCURRENT_STREAMS
+# not enforced) + CVE-2026-50560 (reset variant) + conditional HTTP/1.1 smuggling CVE-2026-50020.
+# >= grpc-netty 1.79 floor 4.1.130; single-Netty convergence (c433f3f) holds; matches Quarkus 3.33.2.1.
+nettyGrpcVersion=4.1.135.Final
 # grpc Netty  <= quarkus Netty ( must has high netty than grpc )
 # https://quarkus.io/blog/lts-releases/
 ## 4.1.100.Final

--- a/gradle.properties
+++ b/gradle.properties
@@ -28,8 +28,11 @@ grpcVersion=1.79.0
 
 #nettyGrpcVersion=4.1.127.Final
 # IOURING-001 Phase 1 CVE wave: 4.1.133 -> 4.1.135.Final. 4.1.135 is the only post-4.1.133
-# 4.1.x with security content; fixes hot-path HTTP/2 DoS CVE-2026-47244 (MAX_CONCURRENT_STREAMS
-# not enforced) + CVE-2026-50560 (reset variant) + conditional HTTP/1.1 smuggling CVE-2026-50020.
+# 4.1.x with security content. netty-codec-http2 fixes: CVE-2026-47244 (MAX_CONCURRENT_STREAMS
+# not enforced, hot-path DoS), CVE-2026-50560 (reset variant, hot-path DoS), CVE-2026-48043
+# (DelegatingDecompressorFrameListener ByteBuf leak — not on krpc's path: grpc compresses at the
+# message layer, not HTTP/2 content-encoding; fixed defensively by the bump). netty-codec-http:
+# CVE-2026-50020 (conditional HTTP/1.1 smuggling). Full tri-state in IOURING-001_RESEARCH_omp.md.
 # >= grpc-netty 1.79 floor 4.1.130; single-Netty convergence (c433f3f) holds; matches Quarkus 3.33.2.1.
 nettyGrpcVersion=4.1.135.Final
 # grpc Netty  <= quarkus Netty ( must has high netty than grpc )


### PR DESCRIPTION
## Summary (5 commits)
1. **docs port** — SPEC §13 native-image consumer SoT (support matrix, gap workarounds), NATIVE-001 roadmap item, INDEX/module wiring.
2. **NATIVE-001 Option A (maintainer-approved)** — `grpcVersion` 1.82.0 → 1.79.0, aligned to the Quarkus 3.33 LTS BOM. The 1.82 pin was habitual, not load-bearing (full source scan: zero post-1.79 API); wire risk nil. Kills the consumer-side `resolutionStrategy` force.
3. **Netty CVE wave** — 4.1.133 → 4.1.135.Final. Closes two live HTTP/2 DoS holes on the gRPC hot path (CVE-2026-47244, CVE-2026-50560) + conditional HTTP/1 smuggling (CVE-2026-50020). Convergence via **build-local** `resolutionStrategy` (all `io.netty:*` = 4.1.135 incl. transitive-only `netty-codec-http2`).
4. **BOM-leak fix (codex r1 blocking)** — no `netty-bom` platform in published POM/GMM; consumer BOMs stay authoritative. Verified by regenerating all 9 publication POMs.
5. **io_uring evaluation docs** — SPEC §13 status note + NATIVE-003 (deferred, gated on Quarkus 4 / Netty 4.2). Flag-gated PoC + benchmark live on `feat/iouring-eval` (eval-only, NOT for merge): native io_uring works but is 5–6% slower than NIO on the typical small-message unary path.

## Verification
- Full `gradle build -x test` green; native test-server build + boot-to-ready **without any io.grpc force**.
- Heterogeneous codex review r1 REQUEST-CHANGES (3 blocking) → all fixed → **r2 APPROVE, 0 new findings** (POM/GMM regeneration probes, `javap`, dependencyInsight audits).
- Not run: `test` task (DB-gated integration tests, per repo convention).

## Follow-ups (workspace decision queue)
- Finite `maxConcurrentCallsPerConnection` default (CVE-2026-47244 app-level hardening) — behavior change, pending maintainer.
- Consumers advised to adopt Quarkus BOM 3.33.2.1 (same Netty 4.1.135 batch).