### PR TITLE
release: 1.0.3

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -380,12 +380,10 @@ substitution matches the class shape.
 
 | krpc release                    | Quarkus LTS | io.grpc | consumer force |
 |---------------------------------|-------------|---------|----------------|
-| next release (this alignment)   | 3.33.x LTS  | 1.79.0  | none — aligned |
+| ≥ 1.0.3 (this alignment)        | 3.33.x LTS  | 1.79.0  | none — aligned |
 | published ≤ 1.0.2               | 3.33.x LTS  | 1.82.0  | required (below) |
 
-(HEAD is still tagged `1.0.2` in `gradle.properties` but already carries the 1.79.0
-alignment; it publishes as the next version bump. Bump `grpcVersion` in lockstep when
-adopting the next Quarkus LTS.)
+(Bump `grpcVersion` in lockstep when adopting the next Quarkus LTS.)
 
 **For published krpc ≤1.0.2 only** (ships io.grpc 1.82.0, skewed above the BOM → native-image
 aborts during Initializing): force `io.grpc:*` back to the BOM version in the root

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,12 @@
 
+# 1.0.3, 2026-07-02
+
+* **grpc aligned to the Quarkus 3.33 LTS BOM: `io.grpc` 1.82.0 -> 1.79.0** (NATIVE-001 Option A). Kills the consumer-side `resolutionStrategy` force previously required for Quarkus native builds; wire behavior unchanged. SPEC §13.1 support matrix.
+* **Netty security wave: 4.1.133 -> 4.1.135.Final.** Closes CVE-2026-47244 + CVE-2026-50560 (HTTP/2 DoS, gRPC hot path) and CVE-2026-50020 (conditional HTTP/1 smuggling). Convergence is build-local (all `io.netty:*` incl. transitive-only `netty-codec-http2`); nothing leaks into published POMs — consumer BOMs stay authoritative. Consumers on Quarkus should adopt BOM 3.33.2.1 (same Netty batch).
+* io_uring transport evaluated (flag-gated PoC on `feat/iouring-eval`, NOT shipped): works in native but 5–6% slower than NIO on the typical small-message unary path; deferred to Quarkus 4 / Netty 4.2 (NATIVE-003). SPEC §13 note.
+* Docs: SPEC §13 rewritten as the native-image consumer SoT (version matrix, server-provider + substitution workarounds pending ext-rpc 1.0.2, build recipe, checklist).
+* Heterogeneously reviewed (codex r1 REQUEST-CHANGES -> fixes -> r2 APPROVE, 0 findings).
+
 # 1.0.2, 2026-06-22
 
 * Per-request server context migrated from a hand-rolled `ThreadLocal` to gRPC-native **`io.grpc.Context`** (`ServerContext` `SC_KEY`; attach/detach in `UnaryMethod`). Behavior-equivalent, no wire change; gRPC-managed scope, virtual-thread-friendly. Heterogeneously reviewed (codex).

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ org.gradle.logging.level=INFO
 # book settings
 #MAVEN_REPO=https://jcr.zhulinkeji.com/artifactory/maven/
 group=tech.krpc
-version=1.0.2
+version=1.0.3
 extRpcVersion=1.0.1
 jandexVersion=2.3.0
 

--- a/gradle/publish-central.sh
+++ b/gradle/publish-central.sh
@@ -140,6 +140,10 @@ build_bundle() {
   [[ "${#staging_dirs[@]}" -gt 0 ]] || die "no module central-staging directories found"
 
   for staging_dir in "${staging_dirs[@]}"; do
+    # ext-rpc-gen releases on its own cycle (SPEC §12) and pins its own version —
+    # bundling it re-uploads an existing GAV and Central rejects the whole bundle
+    # (bit us on the 1.0.0 release). Never include it in the krpc bundle.
+    [[ "$staging_dir" == *"/ext-rpc-gen/"* ]] && continue
     cp -R "$staging_dir"/. "$bundle_dir"/
   done
 


### PR DESCRIPTION
Version bump + changelog + SPEC matrix concretized to 1.0.3; publish-central.sh excludes ext-rpc-gen (duplicate-GAV fix). Central deployment `tech.krpc-krpc-1.0.3` VALIDATED → published (8 modules).