### PR TITLE
docs: agent assets (Wave 2) — official krpc skill, llms.txt, agent guide

### DIFF
--- a/.github/workflows/skill-sync.yml
+++ b/.github/workflows/skill-sync.yml
@@ -1,0 +1,20 @@
+# Guards the self-contained skill bundle: skills/krpc/references/SPEC.md must be a
+# verbatim copy of the repo-root SPEC.md (single source of truth, zero drift).
+name: skill-spec-sync
+on:
+  push:
+    branches: [dev]
+  pull_request:
+permissions:
+  contents: read
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: SPEC.md bundled copy must match root
+        run: |
+          if ! diff -q SPEC.md skills/krpc/references/SPEC.md; then
+            echo "::error::skills/krpc/references/SPEC.md is out of sync with SPEC.md — run: cp SPEC.md skills/krpc/references/SPEC.md"
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ KRPC is an interface-first RPC framework for cloud-native services.
 
 Write a Java interface, publish it as the API contract, and let KRPC handle RPC transport, validation, metadata, and client generation. Service authors do not need to write proto files for normal business APIs.
 
+**AI agent?** Install the [krpc skill](skills/krpc/SKILL.md) and read the [agent guide](docs/agent-guide.md) to discover and call KRPC services over HTTP.
+
 ## What It Does
 
 - Uses gRPC / HTTP/2 as the transport.

--- a/docs-site/docs/reference.md
+++ b/docs-site/docs/reference.md
@@ -15,6 +15,10 @@ differ, the **linked document wins**.
   authoring handbook: method contract, `RpcResult` envelope, soft/hard error
   model, DTO rules, `@RpcService` naming, `@UnsafeWeb`, validation, auth/JWKS,
   and native-image (§13).
+- **[Agent Guide](https://github.com/martin1847/krpc/blob/dev/docs/agent-guide.md)**
+  — how an AI agent discovers and calls KRPC services over HTTP (P0
+  `/agent/discover` + `/agent/invoke`), with a real transcript. The portable
+  quick-reference is the [krpc skill](https://github.com/martin1847/krpc/blob/dev/skills/krpc/SKILL.md).
 
 ## Lifecycle & Security
 

--- a/docs-site/static/llms.txt
+++ b/docs-site/static/llms.txt
@@ -1,0 +1,29 @@
+# KRPC
+
+> KRPC is an interface-first RPC framework for cloud-native services: write a Java
+> interface plus DTOs and the framework handles gRPC/HTTP2 transport, JSON
+> serialization, validation, metadata, and client generation — service authors
+> write no proto files. Service discovery, load balancing, and telemetry are left
+> to Kubernetes / Istio / the deployment platform.
+
+For coding agents: read `SPEC.md` before writing or calling a service, and the
+agent guide before discovering/invoking a running service over HTTP. When this file
+and a linked document disagree, the linked document wins.
+
+## Core documentation
+
+- [SPEC.md](https://raw.githubusercontent.com/martin1847/krpc/dev/SPEC.md): the authoring handbook — method contract, RpcResult envelope, soft/hard error model, DTO rules, @RpcService naming, @UnsafeWeb, validation, auth/JWKS, native image (§13). Source of truth for authoring.
+- [Agent guide](https://raw.githubusercontent.com/martin1847/krpc/dev/docs/agent-guide.md): how an agent discovers and calls a KRPC service over plain HTTP (P0 /agent/discover + /agent/invoke), with a real transcript.
+- [krpc skill](https://raw.githubusercontent.com/martin1847/krpc/dev/skills/krpc/SKILL.md): portable, tool-agnostic quick-reference — the five rules that bite first plus the agent call path.
+- [Quickstart](https://raw.githubusercontent.com/martin1847/krpc/dev/examples/quickstart/README.md): a 5-minute, DB-free, JWT-free service that clones, runs, and answers an RPC call.
+- [Support policy](https://raw.githubusercontent.com/martin1847/krpc/dev/docs/support-policy.md): version/support lifecycle (SPEC §13.1 is the canonical version matrix).
+- [Changelog](https://raw.githubusercontent.com/martin1847/krpc/dev/changelog.md): release notes.
+- [Documentation site](https://martin1847.github.io/krpc/): the published docs site (Getting Started + Reference, linking the canonical repo documents).
+
+## Optional deeper reading
+
+- [Documentation index](https://raw.githubusercontent.com/martin1847/krpc/dev/docs/INDEX.md): the map of the repository source of truth (decisions, modules, roadmap, AI context).
+- [Architecture decision records](https://github.com/martin1847/krpc/tree/dev/docs/decisions): repository scope (ADR-0001), JDK 21 / virtual threads (ADR-0002), W3C trace context (ADR-0003), agent-friendly introspection (ADR-0004).
+- [Active roadmap](https://raw.githubusercontent.com/martin1847/krpc/dev/docs/roadmap/active-roadmap.md): in-flight capabilities, including agent-friendly introspection (AGENT-001).
+- [SECURITY.md](https://raw.githubusercontent.com/martin1847/krpc/dev/SECURITY.md): how to report a vulnerability, response targets, and scope.
+- [README](https://raw.githubusercontent.com/martin1847/krpc/dev/README.md): project overview, module map, and install coordinates.

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -1,0 +1,184 @@
+# Agent Guide — discovering & calling KRPC services over HTTP
+
+How an AI agent (or a human wiring one up) discovers a KRPC service's schema and
+calls a method over plain HTTP/1.1 JSON — no gRPC stack, no compiled client.
+
+This is the **P0 HTTP `discover → invoke` loop** from
+[ADR-0004](decisions/ADR-0004-agent-friendly-introspection.md) (roadmap AGENT-001).
+It exposes KRPC's existing runtime self-description (`RpcMetaService.listApis()` /
+`ApiMeta`) and generic invoke (`GeneralizeClient`) through two HTTP endpoints.
+
+> Authoring rules (method contract, `RpcResult`, errors, DTOs, `@UnsafeWeb`, auth)
+> live in [`SPEC.md`](../SPEC.md). The portable, tool-agnostic quick-reference is
+> the `krpc` skill (`skills/krpc/SKILL.md`). This page is the runtime call surface.
+
+## Endpoints
+
+| method | path | purpose |
+| --- | --- | --- |
+| `GET`  | `/agent/discover` | web-only `ApiMeta` as JSON (services + method signatures + DTO type trees + `@Doc` + validation constraints) |
+| `POST` | `/agent/invoke`   | resolve `Service/method`, forward JSON input verbatim, dispatch through the same credential + filter path as gRPC |
+
+**Port.** These ride the plain-HTTP server on `http.port` (**default `8080`**),
+which is **separate** from the gRPC gateway port `rpc.server.port` (default
+`50051`). The gRPC gateway speaks HTTP/2 framing (use `rpcurl` there); the agent
+endpoints speak plain HTTP/1.1 JSON that any HTTP client can call.
+
+## Exposure model (honest version)
+
+- **The agent surface is a filtered view of the web surface.** `/agent/discover`
+  and `/agent/invoke` see exactly the `@UnsafeWeb` services — the same set the
+  browser/frontend gateway can reach. Services without `@UnsafeWeb` keep their `-`
+  (hidden) prefix and **never** appear in discovery and **cannot** be invoked
+  (unknown and hidden resolve identically to a not-found, with no internal
+  disclosure).
+- **There is no narrower "agent tool" subset yet.** ADR-0004 specifies
+  `@UnsafeWeb(agentTool=true)` as the opt-in that would make the agent surface a
+  deliberate *subset* of the web surface — but that is a **P1 design that is
+  accepted, not yet built**. Today (P0) the agent surface equals the web surface.
+  Do not assume an `agentTool` gate exists.
+- **Credential is not bypassed.** `/agent/invoke` forwards `Authorization: Bearer
+  <jwt>` (and the auth cookie) into the same dispatch path as gRPC, so an
+  `@UnsafeWeb(requireCredential=true)` service still runs its credential check and
+  rejects unauthenticated calls.
+- **Auth and rate-limiting are the gateway's responsibility, not KRPC core.**
+  `/agent/discover` exposes the full schema of every `@UnsafeWeb` service to any
+  caller, and `/agent/invoke` reaches every `requireCredential=false` `@UnsafeWeb`
+  service. A deployment MUST place both paths behind a gateway that enforces auth
+  and rate limits (ADR-0004).
+
+## Request / response shape
+
+`POST /agent/invoke` body:
+
+```json
+{ "service": "<Service>", "method": "<method>", "input": { /* the one DTO, or omit */ } }
+```
+
+- `service` / `method` are **app-relative** — the `app/` prefix is stripped. A
+  service published at `quickstart/Hello/hello` is invoked as
+  `{"service":"Hello","method":"hello"}`.
+- `input` is the method's single request DTO as free-form JSON, forwarded verbatim
+  (the target method does its own deserialization + validation).
+- Responses mirror `RpcResult`: `{"code":0,"data":{…}}` on success;
+  `{"code":<n>,"message":"…"}` on error. **Errors ride the `code` field in the
+  body, not the HTTP status line** — the transport emits only `200` (handled),
+  `404` (unknown path), or `500` (uncaught). Unknown/hidden service → `code:5`
+  (gRPC `NOT_FOUND`).
+
+## A real discover → invoke transcript
+
+Run against the [`examples/quickstart`](../examples/quickstart/) service
+(`@UnsafeWeb` `HelloService`, no DB, no JWT).
+
+> **Prerequisite (known P0 limitation).** The two handler beans are discovered
+> reflectively, so Quarkus Arc's default unused-bean removal strips them and the
+> HTTP server logs `Skip HTTP Server , no Handlers found.` — the endpoints are then
+> absent. Until this is addressed, build the app with unused-bean removal off so
+> the handlers are retained (JVM mode only; native reflection-config for these
+> handlers is also not added yet):
+>
+> ```bash
+> gradle :examples:quickstart:quarkusBuild -x test -Dquarkus.arc.remove-unused-beans=none
+> java -jar examples/quickstart/build/quarkus-app/quarkus-run.jar
+> ```
+>
+> Startup then logs the surface coming up:
+>
+> ```text
+> HttpHandlerExpose  GET [/agent/discover]
+> HttpHandlerExpose  POST [/agent/invoke]
+> HttpHandlerExpose  ***** 【 DEV 】 HTTP Server 2 endpoints  on 8080
+> RpcServiceExpose   ***** 【 DEV 】 RpcServer expose 1 services on 50051
+> ```
+
+### 1. Discover
+
+```bash
+curl http://127.0.0.1:8080/agent/discover
+```
+
+```json
+{
+  "app": "quickstart",
+  "apis": [
+    {
+      "name": "Hello",
+      "methods": [
+        {
+          "name": "hello",
+          "arg": {
+            "rawType": {
+              "name": "HelloRequest", "input": true, "parameterized": false,
+              "fields": [
+                { "name": "name",
+                  "type": { "rawType": { "name": "String", "input": true, "parameterized": false } },
+                  "annotations": [ { "name": "NotBlank", "properties": {} } ] }
+              ]
+            }
+          },
+          "res": {
+            "rawType": {
+              "name": "HelloReply", "input": false, "parameterized": false,
+              "fields": [
+                { "name": "message",   "type": { "rawType": { "name": "String", "input": true,  "parameterized": false } } },
+                { "name": "timestamp", "type": { "rawType": { "name": "Long",   "input": false, "parameterized": false } } }
+              ]
+            }
+          },
+          "annotations": [
+            { "name": "Doc", "properties": { "hidden": false, "value": "Returns a greeting for the given name." } }
+          ]
+        }
+      ],
+      "description": "KRPC quickstart demo service",
+      "web": true
+    }
+  ],
+  "dtos": [ /* HelloRequest, HelloReply, String, Long — the DTO closure */ ],
+  "sdkVersion": "1.0.0",
+  "vendor": "java",
+  "buildVersion": "null-2026-07-03 02:00"
+}
+```
+
+The agent reads: service `Hello`, method `hello`, input `HelloRequest{ name:String
+@NotBlank }`, output `HelloReply{ message:String, timestamp:Long }`, plus the
+`@Doc` description. That is enough to construct a valid call.
+
+### 2. Invoke
+
+```bash
+curl -X POST http://127.0.0.1:8080/agent/invoke \
+  -H 'Content-Type: application/json' \
+  -d '{"service":"Hello","method":"hello","input":{"name":"krpc"}}'
+```
+
+```json
+{"code":0,"data":{"message":"Hello, krpc!","timestamp":1783015301792}}
+```
+
+### 3. Unknown or hidden service → not found
+
+```bash
+curl -X POST http://127.0.0.1:8080/agent/invoke \
+  -H 'Content-Type: application/json' \
+  -d '{"service":"Nope","method":"x","input":{}}'
+```
+
+```json
+{"code":5,"message":"Nope/x not found"}
+```
+
+A hidden (non-`@UnsafeWeb`) service returns the identical `code:5` response — the
+agent cannot distinguish "does not exist" from "exists but hidden", by design.
+
+## What is not here (P1, not built)
+
+- **Native MCP server.** ADR-0004 P1 is a runtime MCP module generated from live
+  `ApiMeta`, Streamable HTTP, feature switch default OFF. **Not started.**
+- **`@UnsafeWeb(agentTool=true)` opt-in.** The agent-tool subset gate above.
+- **In-core auth / rate limiting.** Deferred to the gateway (ADR-0004).
+
+See [ADR-0004](decisions/ADR-0004-agent-friendly-introspection.md) and the
+[active roadmap](roadmap/active-roadmap.md) AGENT-001 entry for phasing.

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -37,10 +37,15 @@ endpoints speak plain HTTP/1.1 JSON that any HTTP client can call.
   deliberate *subset* of the web surface — but that is a **P1 design that is
   accepted, not yet built**. Today (P0) the agent surface equals the web surface.
   Do not assume an `agentTool` gate exists.
-- **Credential is not bypassed.** `/agent/invoke` forwards `Authorization: Bearer
-  <jwt>` (and the auth cookie) into the same dispatch path as gRPC, so an
-  `@UnsafeWeb(requireCredential=true)` service still runs its credential check and
-  rejects unauthenticated calls.
+- **Credential is not bypassed relative to gRPC.** `/agent/invoke` forwards
+  `Authorization: Bearer <jwt>` (and the auth cookie) into the **same credential
+  check as a normal gRPC call**, so an `@UnsafeWeb(requireCredential=true)` service
+  is checked no differently on this path. Whether that check actually **rejects** an
+  unauthenticated call depends on auth being configured: the check enforces only
+  when a credential verifier is registered — i.e. `rpc.server.jwks` is set and
+  loads. With JWKS missing or unloadable and `exitOnJwksError` off, the check
+  **silently skips** (SPEC §8.7). Configure JWKS and set `exitOnJwksError=true` in
+  prod; this path adds no security guarantee beyond what that configuration gives.
 - **Auth and rate-limiting are the gateway's responsibility, not KRPC core.**
   `/agent/discover` exposes the full schema of every `@UnsafeWeb` service to any
   caller, and `/agent/invoke` reaches every `requireCredential=false` `@UnsafeWeb`

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -37,15 +37,19 @@ endpoints speak plain HTTP/1.1 JSON that any HTTP client can call.
   deliberate *subset* of the web surface — but that is a **P1 design that is
   accepted, not yet built**. Today (P0) the agent surface equals the web surface.
   Do not assume an `agentTool` gate exists.
-- **Credential is not bypassed relative to gRPC.** `/agent/invoke` forwards
-  `Authorization: Bearer <jwt>` (and the auth cookie) into the **same credential
-  check as a normal gRPC call**, so an `@UnsafeWeb(requireCredential=true)` service
-  is checked no differently on this path. Whether that check actually **rejects** an
-  unauthenticated call depends on auth being configured: the check enforces only
-  when a credential verifier is registered — i.e. `rpc.server.jwks` is set and
-  loads. With JWKS missing or unloadable and `exitOnJwksError` off, the check
-  **silently skips** (SPEC §8.7). Configure JWKS and set `exitOnJwksError=true` in
-  prod; this path adds no security guarantee beyond what that configuration gives.
+- **Credential is not bypassed relative to gRPC.** `/agent/invoke` forwards the
+  `Authorization: Bearer <jwt>` header into the **same credential check as a normal
+  gRPC call**, so an `@UnsafeWeb(requireCredential=true)` service is checked no
+  differently on this path. Note the agent path forwards **only** `Authorization`
+  (plus client-id and `traceparent`) — it does **not** forward a `Cookie` header, so
+  the cookie-based credential fallback that works on the web/gRPC path is **not
+  available on the agent surface** in the current implementation; send the JWT as a
+  bearer token. Whether the check actually **rejects** an unauthenticated call
+  depends on auth being configured: it enforces only when a credential verifier is
+  registered — i.e. `rpc.server.jwks` is set and loads. With JWKS missing or
+  unloadable and `exitOnJwksError` off, the check **silently skips** (SPEC §8.7).
+  Configure JWKS and set `exitOnJwksError=true` in prod; this path adds no security
+  guarantee beyond what that configuration gives.
 - **Auth and rate-limiting are the gateway's responsibility, not KRPC core.**
   `/agent/discover` exposes the full schema of every `@UnsafeWeb` service to any
   caller, and `/agent/invoke` reaches every `requireCredential=false` `@UnsafeWeb`

--- a/docs/orchestration/OSS-001_WAVE2_IMPL_omp.md
+++ b/docs/orchestration/OSS-001_WAVE2_IMPL_omp.md
@@ -17,7 +17,7 @@ docs/文本资产，零代码/零发布面变更。依据 STRAT-001 R2 #1 / ADR-
    /agent/invoke，8080 vs 50051）、暴露模型诚实版、请求/响应形状、真实 discover→invoke
    实录、"未建"清单。docs-site 经 `reference.md` 挂链。
 
-指针（每处一行，diff 里唯二的 tracked 改动）：
+指针（每处一行）：
 - `README.md`：intro 后一行 "AI agent? install the krpc skill + agent guide"。
 - `docs-site/docs/reference.md`：Handbook 节加 Agent Guide + skill 链接（= docs-site 挂链）。
 
@@ -42,7 +42,7 @@ docs/文本资产，零代码/零发布面变更。依据 STRAT-001 R2 #1 / ADR-
 
 ## 未验证 / 假设
 
-- **已 commit（5 个独立 docs commit，off `2ff124b`），未 push、未开 PR**（按 guardrail；codex r1 回修后待 r2）。
+- **已 commit（多个独立 docs commit，off `2ff124b`；确切数量见 `git log`），未 push、未开 PR**（按 guardrail；codex 回修中）。
 - curl 实录在 **JVM 模式 + `quarkus.arc.remove-unused-beans=none`** 下取得（见下方 FINDING）。
   未在 native 模式验证（P0 已知 native reflection-config 未加）。
 - quarkusDev（`gradle :examples:quickstart:run`）在本机因 dev-mode 模型解析
@@ -81,13 +81,22 @@ reflection-config 未加"。此 **Arc 移除 caveat 是新发现，任何默认�
 (c) `HttpHandlerExpose` 显式 `@Inject Instance<GetHandler>` / `Instance<PostHandler<?>>`
 建立强引用。建议开 roadmap/issue 承接。
 
+## 附带记录（Wave 3 P0 fix 时顺手，勿在本分支动 Java）
+
+- **`AgentInvokeHandler.java:33-36` 注释与代码不符（codex r2 advisory）**：javadoc 写 not-found/
+  forbidden "surface as `code:404`"，但 `CODE_NOT_FOUND = 5`（:43），实际 body 返回 `{"code":5,…}`
+  （实录已证）。本分支 docs-only，**未动 Java**；Wave 3 修 P0（handler 保留）时顺手把注释 404 改为 5。
+
 ## 措辞纪律自检（disclosure 口径）
 
 - 全套文本无 "complete" 声称（skill/agent-guide/llms.txt 均未用）。
 - `agentTool` 一律标 **accepted-not-built / P1 design**（skill + agent-guide 各一处显式）。
 - @UnsafeWeb 暴露模型写诚实版：**agent 面 = web 面过滤视图**；`agentTool` 严格子集为未建
   P1，引 ADR-0004。
-- 凭据不被绕过、auth/限流为 gateway 职责——按 ADR-0004 原文。
+- 凭据措辞按代码事实（codex r1+r2 回修）：invoke 走与普通调用相同的凭据检查，但**实际拒绝取决于
+  JWKS/auth 是否配置**（verifier 注册才生效，否则静默跳过，SPEC §8.7）；agent 路径仅转发
+  `Authorization`（+ client-id/traceparent），**不转发 Cookie**，故 cookie 凭据回退不适用于 agent 面
+  （`AgentInvokeHandler.toMetadata:113-119`）。auth/限流为 gateway 职责——按 ADR-0004 原文。
 
 ## SoT / 边界
 

--- a/docs/orchestration/OSS-001_WAVE2_IMPL_omp.md
+++ b/docs/orchestration/OSS-001_WAVE2_IMPL_omp.md
@@ -35,13 +35,14 @@ docs/文本资产，零代码/零发布面变更。依据 STRAT-001 R2 #1 / ADR-
   `RefUtils.java:117-120`（方法过滤）、`:124-150`（HIDDEN_SERVICE `-` 前缀）、
   `RpcResult.java:21-24`（百/千分桶、无负码、禁异常传业务错）——与 SPEC 引用一致。
 - **`gradle build -x test` 绿**（JDK 21 baseline，Gradle 9.6.0 @ /opt/gradle）。
-- **diff 形态**：tracked = README +2 / reference.md +4（仅指针）；untracked = `llms.txt`、
-  `docs-site/static/llms.txt`、`docs/agent-guide.md`、`skills/krpc/SKILL.md`。**零 Java/gradle
-  逻辑变更**，发布模块集不动。
+- **diff 形态**：改动为纯文本资产 —— 修改 `README.md`（+2）/ `docs-site/docs/reference.md`（+4，仅指针），
+  新增 `llms.txt`、`docs-site/static/llms.txt`、`docs/agent-guide.md`、`skills/krpc/SKILL.md`、
+  本 IMPL 文档、`docs/roadmap/active-roadmap.md`（AGENT-001 caveat）。**零 Java/gradle 逻辑变更**，
+  发布模块集不动。
 
 ## 未验证 / 假设
 
-- **未 push、未开 PR、未 commit**（按 guardrail；等 reviewer codex r1+r2 后再定 commit 切分）。
+- **已 commit（5 个独立 docs commit，off `2ff124b`），未 push、未开 PR**（按 guardrail；codex r1 回修后待 r2）。
 - curl 实录在 **JVM 模式 + `quarkus.arc.remove-unused-beans=none`** 下取得（见下方 FINDING）。
   未在 native 模式验证（P0 已知 native reflection-config 未加）。
 - quarkusDev（`gradle :examples:quickstart:run`）在本机因 dev-mode 模型解析

--- a/docs/orchestration/OSS-001_WAVE2_IMPL_omp.md
+++ b/docs/orchestration/OSS-001_WAVE2_IMPL_omp.md
@@ -1,0 +1,94 @@
+# OSS-001 Wave 2 IMPL (omp) — agent 资产三件套
+
+Branch: `feat/agent-assets` off `origin/dev` @ `2ff124b`. Executor: omp. Scope:
+docs/文本资产，零代码/零发布面变更。依据 STRAT-001 R2 #1 / ADR-0004 / roadmap AGENT-001。
+
+## 交付物（拟各自独立 commit）
+
+1. **官方 krpc agent skill** — `skills/krpc/SKILL.md`。thin-shim（SoT=SPEC.md）：
+   frontmatter（name `krpc` + 触发词）；五条速查（SPEC §1–§6，每条一行 + 节号指针）；
+   agent 调用路径 curl 模板（P0 discover→invoke，端口/键格式/错误语义/凭据不绕过/agentTool
+   未建）；native 指针（SPEC §13 + krpc-native-build skill）。参照 workspace
+   `krpc-native-build` skill 的 thin-shim 先例。
+2. **`llms.txt`** — repo 根 + `docs-site/static/llms.txt`（双落点，内容一致）。llmstxt.org
+   格式（H1 + 摘要 + 分节链接）。仓内文档用 `raw.githubusercontent.com/martin1847/krpc/dev/…`；
+   docs-site 用终态 `https://martin1847.github.io/krpc/`。
+3. **Agent 入口文档** — `docs/agent-guide.md`。端点表（GET /agent/discover、POST
+   /agent/invoke，8080 vs 50051）、暴露模型诚实版、请求/响应形状、真实 discover→invoke
+   实录、"未建"清单。docs-site 经 `reference.md` 挂链。
+
+指针（每处一行，diff 里唯二的 tracked 改动）：
+- `README.md`：intro 后一行 "AI agent? install the krpc skill + agent guide"。
+- `docs-site/docs/reference.md`：Handbook 节加 Agent Guide + skill 链接（= docs-site 挂链）。
+
+## 验证（真跑）
+
+- **curl 实录真跑**（agent-guide 核心验收）。起 quickstart fast-jar，实测：
+  - `GET /agent/discover` → 返回 web-only `ApiMeta`（Hello 服务、HelloRequest.name
+    `@NotBlank`、HelloReply、`@Doc`、`web:true`）。真实 JSON 已贴入 agent-guide。
+  - `POST /agent/invoke {"service":"Hello","method":"hello","input":{"name":"krpc"}}`
+    → `{"code":0,"data":{"message":"Hello, krpc!","timestamp":1783015301792}}`。
+  - unknown/hidden → `{"code":5,"message":"Nope/x not found"}`。
+- **llms.txt 链接核验**：12 条链接全过（仓内 8 条本地文件存在；docs-site URL 形态合法）。
+- **五条速查对照 SPEC**：逐条比对 SPEC §1–§6 原文（§1 L17-40 / §2 L49-73 / §3 L77-110 /
+  §4 L114-135 / §6 L160-178），措辞忠实、节号指针正确、无转述失真。底层代码证据抽验：
+  `RefUtils.java:117-120`（方法过滤）、`:124-150`（HIDDEN_SERVICE `-` 前缀）、
+  `RpcResult.java:21-24`（百/千分桶、无负码、禁异常传业务错）——与 SPEC 引用一致。
+- **`gradle build -x test` 绿**（JDK 21 baseline，Gradle 9.6.0 @ /opt/gradle）。
+- **diff 形态**：tracked = README +2 / reference.md +4（仅指针）；untracked = `llms.txt`、
+  `docs-site/static/llms.txt`、`docs/agent-guide.md`、`skills/krpc/SKILL.md`。**零 Java/gradle
+  逻辑变更**，发布模块集不动。
+
+## 未验证 / 假设
+
+- **未 push、未开 PR、未 commit**（按 guardrail；等 reviewer codex r1+r2 后再定 commit 切分）。
+- curl 实录在 **JVM 模式 + `quarkus.arc.remove-unused-beans=none`** 下取得（见下方 FINDING）。
+  未在 native 模式验证（P0 已知 native reflection-config 未加）。
+- quarkusDev（`gradle :examples:quickstart:run`）在本机因 dev-mode 模型解析
+  `com.google.inject:guice:5.1.0` 的 `classes` classifier 变体失败（`mavenLocal()` 优先、
+  该 classifier 变体不在本地库）——与本次交付无关，绕过方式：`quarkusBuild` 出 fast-jar 后
+  `java -jar` 直跑。用户环境若有独立 dev-mode 通路，实录命令可切回 quarkusDev。
+
+## FINDING（新，需上游关注）— P0 agent 端点在默认 Quarkus 应用中不暴露
+
+**现象**：quickstart fast-jar 默认启动打出 `HttpHandlerExpose: Skip HTTP Server , no
+Handlers found.`，8080 不监听，`/agent/discover`、`/agent/invoke` 连接被拒（curl exit 7）。
+gRPC 网关 50051 正常。
+
+**根因**：`AgentDiscoverHandler`（`GetHandler`）/`AgentInvokeHandler`（`PostHandler`）是
+`@ApplicationScoped` bean，但**无人 `@Inject` 它们**——`HttpHandlerExpose.initHandler()`
+只在运行时用 `beanManager.getBeans(Object.class, Any)` 反射发现。Quarkus Arc 默认
+`remove-unused-beans=all` 判定二者"未使用"并移除，故运行时扫不到，HTTP server 直接 skip。
+
+**证据**：以 `-Dquarkus.arc.remove-unused-beans=none` 重建同一 fast-jar，启动即打出
+`GET [/agent/discover]` / `POST [/agent/invoke]` / `HTTP Server 2 endpoints on 8080`，
+三条 curl 全部按预期返回（见上）。开/关该 flag 是唯一变量。
+
+**为何测试没抓到**：`AgentInvokeHandlerTest` / `WebMethodRegistryTest` 用 `new
+AgentInvokeHandler()` + 手工 `registry.init(...)` 直接构造，从不启动 Quarkus 容器，故
+Arc bean 移除路径完全不被覆盖。
+
+**影响**：roadmap AGENT-001 标 "P0 (DONE, on dev)"，已知 caveat 仅列 "native
+reflection-config 未加"。此 **Arc 移除 caveat 是新发现，任何默认配置的 Quarkus 消费者
+（含 quickstart 本身）P0 端点开箱不可达**。
+
+**处置**：本 wave 为 docs-only、零代码变更，**不在此修**。agent-guide 已以显式"已知 P0
+限制 + 复现 flag"诚实登记，不谎称开箱可用。修复属独立代码变更（需批准），候选：
+(a) 让 `rpc-server-quarkus` 成为带 deployment 的 Quarkus 扩展，用
+`AdditionalBeanBuildItem(...).setUnremovable()` / `UnremovableBeanBuildItem` 保留
+`GetHandler`/`PostHandler` 实现；(b) handler 上加 `@io.quarkus.arc.Unremovable`；
+(c) `HttpHandlerExpose` 显式 `@Inject Instance<GetHandler>` / `Instance<PostHandler<?>>`
+建立强引用。建议开 roadmap/issue 承接。
+
+## 措辞纪律自检（disclosure 口径）
+
+- 全套文本无 "complete" 声称（skill/agent-guide/llms.txt 均未用）。
+- `agentTool` 一律标 **accepted-not-built / P1 design**（skill + agent-guide 各一处显式）。
+- @UnsafeWeb 暴露模型写诚实版：**agent 面 = web 面过滤视图**；`agentTool` 严格子集为未建
+  P1，引 ADR-0004。
+- 凭据不被绕过、auth/限流为 gateway 职责——按 ADR-0004 原文。
+
+## SoT / 边界
+
+- 触及 SoT：ADR-0004（引用未改）、roadmap AGENT-001（引用未改）、SPEC §1–§6/§13（引用未改）。
+- 无 FOR/NOT FOR 边界变更；无 ADR/roadmap 状态需改（除上方 FINDING 建议新开条目承接 P0 修复）。

--- a/docs/roadmap/active-roadmap.md
+++ b/docs/roadmap/active-roadmap.md
@@ -108,9 +108,24 @@ Phases (sequenced P0 → P1):
   `UnaryMethod.invokeWeb`. Hidden services double-filtered, credential not bypassed,
   filter chain single-pass. Security review APPROVE (0 blocking). JVM-mode only —
   native reflection-config for the new handlers not yet added.
+  - **Caveat (bean removal):** the `AgentDiscoverHandler` / `AgentInvokeHandler`
+    beans are discovered reflectively (`HttpHandlerExpose` scans `getBeans(Object,
+    Any)`), so Quarkus Arc's default `remove-unused-beans=all` strips them as
+    unused and the HTTP server logs `Skip HTTP Server , no Handlers found.` — the
+    endpoints are then absent in a **default Quarkus consumer** (including
+    `examples/quickstart`). Reproduce the working surface with
+    `-Dquarkus.arc.remove-unused-beans=none`. The unit tests instantiate the
+    handlers with `new`, so they never exercise the container path and did not
+    catch this. Fix is folded into P1 as its prerequisite first step (below).
 - **P1** — Runtime MCP server module generated from live `ApiMeta`, Streamable
   HTTP transport, **feature switch default OFF**. Tools = methods opted in via
   `@UnsafeWeb(agentTool=true)` (default `false`).
+  - **Prerequisite (first step):** make the P0 handler beans survive default Arc
+    bean removal (e.g. a `rpc-server-quarkus` deployment module emitting
+    `UnremovableBeanBuildItem` / `AdditionalBeanBuildItem().setUnremovable()`,
+    `@Unremovable` on the handlers, or an explicit `Instance<GetHandler>` /
+    `Instance<PostHandler<?>>` reference), so agent endpoints are reachable in a
+    default consumer before the MCP bridge builds on them.
 
 Acceptance Criteria:
 

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,29 @@
+# KRPC
+
+> KRPC is an interface-first RPC framework for cloud-native services: write a Java
+> interface plus DTOs and the framework handles gRPC/HTTP2 transport, JSON
+> serialization, validation, metadata, and client generation — service authors
+> write no proto files. Service discovery, load balancing, and telemetry are left
+> to Kubernetes / Istio / the deployment platform.
+
+For coding agents: read `SPEC.md` before writing or calling a service, and the
+agent guide before discovering/invoking a running service over HTTP. When this file
+and a linked document disagree, the linked document wins.
+
+## Core documentation
+
+- [SPEC.md](https://raw.githubusercontent.com/martin1847/krpc/dev/SPEC.md): the authoring handbook — method contract, RpcResult envelope, soft/hard error model, DTO rules, @RpcService naming, @UnsafeWeb, validation, auth/JWKS, native image (§13). Source of truth for authoring.
+- [Agent guide](https://raw.githubusercontent.com/martin1847/krpc/dev/docs/agent-guide.md): how an agent discovers and calls a KRPC service over plain HTTP (P0 /agent/discover + /agent/invoke), with a real transcript.
+- [krpc skill](https://raw.githubusercontent.com/martin1847/krpc/dev/skills/krpc/SKILL.md): portable, tool-agnostic quick-reference — the five rules that bite first plus the agent call path.
+- [Quickstart](https://raw.githubusercontent.com/martin1847/krpc/dev/examples/quickstart/README.md): a 5-minute, DB-free, JWT-free service that clones, runs, and answers an RPC call.
+- [Support policy](https://raw.githubusercontent.com/martin1847/krpc/dev/docs/support-policy.md): version/support lifecycle (SPEC §13.1 is the canonical version matrix).
+- [Changelog](https://raw.githubusercontent.com/martin1847/krpc/dev/changelog.md): release notes.
+- [Documentation site](https://martin1847.github.io/krpc/): the published docs site (Getting Started + Reference, linking the canonical repo documents).
+
+## Optional deeper reading
+
+- [Documentation index](https://raw.githubusercontent.com/martin1847/krpc/dev/docs/INDEX.md): the map of the repository source of truth (decisions, modules, roadmap, AI context).
+- [Architecture decision records](https://github.com/martin1847/krpc/tree/dev/docs/decisions): repository scope (ADR-0001), JDK 21 / virtual threads (ADR-0002), W3C trace context (ADR-0003), agent-friendly introspection (ADR-0004).
+- [Active roadmap](https://raw.githubusercontent.com/martin1847/krpc/dev/docs/roadmap/active-roadmap.md): in-flight capabilities, including agent-friendly introspection (AGENT-001).
+- [SECURITY.md](https://raw.githubusercontent.com/martin1847/krpc/dev/SECURITY.md): how to report a vulnerability, response targets, and scope.
+- [README](https://raw.githubusercontent.com/martin1847/krpc/dev/README.md): project overview, module map, and install coordinates.

--- a/skills/krpc/SKILL.md
+++ b/skills/krpc/SKILL.md
@@ -35,6 +35,8 @@ Each line is a pointer, not the spec. Read the cited SPEC section before relying
    (`Integer`/`Long`/`Boolean`/`Float`/`Double`), never primitives: JSON
    serialization is `NON_NULL`, so a primitive serializes as `0`/`false` and
    destroys the "absent vs zero" distinction. Avoid `Map` and `enum` in response DTOs.
+   `byte[]` is the one type passed bare on the wire (not JSON-boxed) — but TS/Dart
+   clients cannot **send** `byte[]` as input.
 5. **@UnsafeWeb — SPEC §6.** TYPE-level `@UnsafeWeb` marks a service reachable
    directly by browsers/frontend over the HTTP gateway; **without it** the service
    name is `-`-prefixed (hidden) and stays service-to-service only. Add it ONLY to
@@ -63,8 +65,12 @@ curl -X POST http://HOST:8080/agent/invoke \
   `quickstart/Hello/hello` as `{"service":"Hello","method":"hello"}`.
 - Errors ride a `code` field in the JSON body (gRPC-style status); the HTTP status
   line stays `200` (transport emits only 200/404/500).
-- **Credential is not bypassed.** `Authorization: Bearer <jwt>` (or the auth
-  cookie) is forwarded and `requireCredential` services still run the check.
+- **Credential is not bypassed relative to gRPC.** `Authorization: Bearer <jwt>`
+  (or the auth cookie) is forwarded into the same credential check as a normal call;
+  a `requireCredential` service is checked no differently here. Actual **rejection**
+  depends on auth being configured — the check enforces only when a verifier is
+  registered (`rpc.server.jwks` set + loaded); missing/unloadable JWKS with
+  `exitOnJwksError` off silently skips it (SPEC §8.7, `exitOnJwksError=true` in prod).
 - **Auth and rate-limiting are the gateway's job**, not krpc core — put these two
   paths behind a gateway (ADR-0004).
 - **`@UnsafeWeb(agentTool=…)` is not built yet** — a P1 design in ADR-0004. P0 gates

--- a/skills/krpc/SKILL.md
+++ b/skills/krpc/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: krpc
+description: "Authoring and calling KRPC (tech.krpc) services. Use when writing or debugging a service that depends on tech.krpc / tech.krpc.ext, or when you see @RpcService, RpcResult<…>, @UnsafeWeb, discover→invoke over HTTP, or a Quarkus/GraalVM native build error from a krpc consumer. Covers the five rules that bite first (method signature, RpcResult, soft/hard errors, boxed DTOs, @UnsafeWeb), the HTTP agent discover→invoke path, and where native-image help lives. Do NOT use for non-krpc gRPC or plain JVM builds."
+---
+
+# krpc — authoring & calling krpc services (thin shim)
+
+> **SoT is the krpc repo `SPEC.md`** — the tool-agnostic authoring handbook with
+> `file:line` code evidence. This skill is a trigger + quick-reference only; when
+> it and `SPEC.md` disagree, **`SPEC.md` wins**. Governance authority is `AGENTS.md`
+> + ADRs (`docs/decisions/`).
+>
+> - Full handbook: `SPEC.md` (repo root, or the release distribution).
+> - Agents discovering/calling a running service: read `docs/agent-guide.md`.
+> - Native-image consumers: `SPEC.md` §13 + the `krpc-native-build` skill.
+
+## Five rules that bite first (condensed from SPEC §1–§6)
+
+Each line is a pointer, not the spec. Read the cited SPEC section before relying on it.
+
+1. **Method signature — SPEC §1.** Every RPC method is `RpcResult<Dto> m(OneDto)`
+   or `m()`: the return type MUST be `RpcResult<…>` and there is **at most one
+   parameter**. Violate either and the method is **silently dropped** — not
+   registered, no startup error, fails to resolve at call time. Merge multiple
+   inputs into one DTO.
+2. **RpcResult envelope — SPEC §2.** `code` `0`=OK / `>0`=business error
+   (**no negative codes**); `msg` is non-null only when `code>0`; `data` is
+   non-null only when `code==0`. Build with `RpcResult.ok(data)` /
+   `RpcResult.error(code,msg)`; callers read `data` only after `isOk()`.
+3. **Soft vs hard errors — SPEC §3.** Business failures **return**
+   `RpcResult.error(code,msg)` — do **not** throw. System / security / validation /
+   unexpected errors **throw** (the server wraps them in a gRPC `Status`, message
+   **truncated to 100 chars**). Never use a Java exception to carry a business error.
+4. **Boxed DTO fields — SPEC §4.** Scalar DTO fields MUST be boxed
+   (`Integer`/`Long`/`Boolean`/`Float`/`Double`), never primitives: JSON
+   serialization is `NON_NULL`, so a primitive serializes as `0`/`false` and
+   destroys the "absent vs zero" distinction. Avoid `Map` and `enum` in response DTOs.
+5. **@UnsafeWeb — SPEC §6.** TYPE-level `@UnsafeWeb` marks a service reachable
+   directly by browsers/frontend over the HTTP gateway; **without it** the service
+   name is `-`-prefixed (hidden) and stays service-to-service only. Add it ONLY to
+   frontend-facing services. `@UnsafeWeb(requireCredential=true)` (class) or
+   `@UnsafeWeb.RequireCredential` (method) requires a JWT — you own the hardening.
+
+## Agent call path — HTTP discover → invoke (P0, ADR-0004)
+
+A running krpc server can be introspected and called over plain HTTP/1.1 JSON — no
+gRPC stack. **These endpoints are on the plain-HTTP port (`http.port`, default
+`8080`), which is separate from the gRPC gateway port (`rpc.server.port`, default
+`50051`).**
+
+```bash
+# 1. Discover: web-only ApiMeta (only @UnsafeWeb services; hidden ones never appear)
+curl http://HOST:8080/agent/discover
+
+# 2. Invoke: app-relative Service/method + verbatim JSON input
+curl -X POST http://HOST:8080/agent/invoke \
+  -H 'Content-Type: application/json' \
+  -d '{"service":"<Service>","method":"<method>","input":{ ... }}'
+# success -> {"code":0,"data":{...}}   unknown/hidden -> {"code":5,...}
+```
+
+- `service`/`method` are **app-relative** (the `app/` prefix is stripped): call
+  `quickstart/Hello/hello` as `{"service":"Hello","method":"hello"}`.
+- Errors ride a `code` field in the JSON body (gRPC-style status); the HTTP status
+  line stays `200` (transport emits only 200/404/500).
+- **Credential is not bypassed.** `Authorization: Bearer <jwt>` (or the auth
+  cookie) is forwarded and `requireCredential` services still run the check.
+- **Auth and rate-limiting are the gateway's job**, not krpc core — put these two
+  paths behind a gateway (ADR-0004).
+- **`@UnsafeWeb(agentTool=…)` is not built yet** — a P1 design in ADR-0004. P0 gates
+  agent exposure on `@UnsafeWeb` only; there is no narrower agent-tool subset today.
+- **Caveats:** JVM-mode only (native reflection-config for these handlers is not
+  added); and in a minimal Quarkus app the handler beans must be retained — see
+  `docs/agent-guide.md` for the runtime note and a real discover→invoke transcript.
+
+## Native image (GraalVM / Quarkus)
+
+Building a krpc consumer as a native image? The single source of truth is
+**`SPEC.md` §13** (version matrix, `ext-rpc` server support, build recipe,
+reflection coverage, checklist). The `krpc-native-build` skill is the trigger +
+fallback cheat-sheet for the same content.

--- a/skills/krpc/SKILL.md
+++ b/skills/krpc/SKILL.md
@@ -65,12 +65,15 @@ curl -X POST http://HOST:8080/agent/invoke \
   `quickstart/Hello/hello` as `{"service":"Hello","method":"hello"}`.
 - Errors ride a `code` field in the JSON body (gRPC-style status); the HTTP status
   line stays `200` (transport emits only 200/404/500).
-- **Credential is not bypassed relative to gRPC.** `Authorization: Bearer <jwt>`
-  (or the auth cookie) is forwarded into the same credential check as a normal call;
-  a `requireCredential` service is checked no differently here. Actual **rejection**
-  depends on auth being configured — the check enforces only when a verifier is
-  registered (`rpc.server.jwks` set + loaded); missing/unloadable JWKS with
-  `exitOnJwksError` off silently skips it (SPEC §8.7, `exitOnJwksError=true` in prod).
+- **Credential is not bypassed relative to gRPC.** The `Authorization: Bearer <jwt>`
+  header is forwarded into the same credential check as a normal call; a
+  `requireCredential` service is checked no differently here. The agent path forwards
+  **only** `Authorization` (plus client-id / `traceparent`) — **no `Cookie` header**,
+  so the cookie credential fallback works on the web/gRPC path but **not on the agent
+  surface** (current impl); send a bearer token. Actual **rejection** depends on auth
+  being configured — the check enforces only when a verifier is registered
+  (`rpc.server.jwks` set + loaded); missing/unloadable JWKS with `exitOnJwksError` off
+  silently skips it (SPEC §8.7, `exitOnJwksError=true` in prod).
 - **Auth and rate-limiting are the gateway's job**, not krpc core — put these two
   paths behind a gateway (ADR-0004).
 - **`@UnsafeWeb(agentTool=…)` is not built yet** — a P1 design in ADR-0004. P0 gates

--- a/skills/krpc/SKILL.md
+++ b/skills/krpc/SKILL.md
@@ -10,7 +10,10 @@ description: "Authoring and calling KRPC (tech.krpc) services. Use when writing 
 > it and `SPEC.md` disagree, **`SPEC.md` wins**. Governance authority is `AGENTS.md`
 > + ADRs (`docs/decisions/`).
 >
-> - Full handbook: `SPEC.md` (repo root, or the release distribution).
+> - Full handbook: **`references/SPEC.md` bundled next to this skill** (verbatim,
+>   release-synced copy of the repo-root `SPEC.md` — CI fails if they diverge), so the
+>   skill stays self-contained when copied into a consumer project. In the krpc repo
+>   itself, the root `SPEC.md` is the canonical copy.
 > - Agents discovering/calling a running service: read `docs/agent-guide.md`.
 > - Native-image consumers: `SPEC.md` §13 + the `krpc-native-build` skill.
 

--- a/skills/krpc/references/SPEC.md
+++ b/skills/krpc/references/SPEC.md
@@ -1,0 +1,508 @@
+# KRPC Development Spec
+
+A tool-agnostic handbook for any coding agent (Claude, Codex, …) **writing or
+calling KRPC services**. It encodes the framework's authoring conventions with
+code evidence (`file:line`). Governance/architecture authority lives in
+[`AGENTS.md`](AGENTS.md) + ADRs + `docs/`; when they conflict with this file,
+they win. Build/release is in [§12](#12-build-test-release).
+
+KRPC is **interface-first**: you write a Java interface + DTOs; the framework
+handles transport (gRPC/HTTP2), JSON serialization, validation, metadata, and
+client generation. Service authors write **no proto files**.
+
+---
+
+## 1. The method contract (the one rule that bites first)
+
+Every RPC method MUST be:
+
+```java
+RpcResult<SomeDto> methodName(OneDto req)   // exactly one param
+RpcResult<SomeDto> methodName()             // or zero params
+```
+
+Two hard constraints, both enforced at the **only** method-discovery point
+(`rpc-common/.../util/RefUtils.java:117-120`):
+
+```java
+.filter(m -> m.getReturnType() == RpcResult.class && m.getParameterCount() <= 1)
+```
+
+- **Return type must be `RpcResult<…>`.**
+- **At most one parameter.**
+
+A method violating either is **silently dropped** — not registered, no error at
+startup; the call just fails to resolve at runtime. This is the single most
+common mistake.
+
+- **DO:** merge multiple inputs into one DTO. Built-in generic wrappers exist:
+  `PagedQuery<T>` (`rpc-api/.../PagedQuery.java`), e.g. `plistBk(PagedQuery<Book> q)`.
+- **DON'T:** `m(Long id, String name)` (two params) or `SomeDto m(...)` (raw return).
+
+The wire protocol has a single input slot; the server reads only
+`inputArgTypes[0]` (`rpc-server/.../UnaryMethod.java:70-71`).
+
+---
+
+## 2. RpcResult — the response envelope
+
+`rpc-api/.../model/RpcResult.java`. Three fields, success/failure mutually
+exclusive:
+
+| field | meaning |
+| --- | --- |
+| `int code` | `0` = OK; `> 0` = business error. **No negative codes.** |
+| `String msg` | non-null only when `code > 0` |
+| `DTO data` | non-null only when `code == 0` |
+
+```java
+return RpcResult.ok(data);          // asserts data != null
+return RpcResult.error(666, "...");  // asserts code > 0 && msg != null
+result.isOk();                       // code == 0
+result.ifOk(fn); result.orElseThrow();
+```
+
+Business error codes are **bucketed by hundreds; large domains by thousands**
+(`RpcResult.java:21-22`). The numeric space is a superset of `google.rpc.Code`
+(see `CommonCode`).
+
+Callers read `data` only after `isOk()` (`rpc-client/.../ClientResult.java:32-41`).
+
+- **DO:** `ok(nonNullData)` / `error(positiveCode, msg)`.
+- **DON'T:** return a bare DTO, use negative codes, set `msg` on success or
+  `data` on failure, or call `ok(null)` (assertion fails).
+
+---
+
+## 3. Error model — soft vs hard exceptions
+
+Two **different channels**. Pick deliberately.
+
+### Soft (business failure) → return, don't throw
+Expected business failures return through `RpcResult.code`. The client gets a
+normal `RpcResult` with `isOk()==false`.
+
+```java
+public RpcResult<Integer> testLogicError(Integer i) {
+    return RpcResult.error(666, "业务逻辑失败");   // DemoServiceImpl.java:43-46
+}
+```
+`RpcResult.java:22-24` is explicit: **do not use Java exceptions to convey
+business errors — define an error code instead.**
+
+### Hard (system/security/validation) → throw
+System errors, auth failures, validation failures, and unexpected
+`RuntimeException`s are thrown. The server catches everything
+(`UnaryMethod.java:212-231`): a `StatusException`/`StatusRuntimeException` passes
+through as-is; anything else is wrapped in `Status.UNKNOWN` with the message
+**truncated to 100 chars** and an error log keyed by `traceId`.
+
+| | Soft | Hard |
+| --- | --- | --- |
+| trigger | business rule unmet | system / security / validation / unexpected |
+| express | `return RpcResult.error(code,msg)` | `throw` (prefer `Status.X.withDescription(..).asRuntimeException()`) |
+| code | business code (hundreds/thousands) | gRPC Status code |
+| client sees | normal `RpcResult`, `!isOk()` | gRPC `onError` / `StatusRuntimeException` |
+| logged | no | `log.error(traceId, ex)` |
+
+- **DON'T:** throw for business errors; rely on exception messages reaching the
+  client intact (they're truncated to 100 chars).
+- Document codes with `@Doc.ErrorCode(code=, when=, message=)` (`Doc.java:37-52`).
+
+---
+
+## 4. DTO rules
+
+### Use boxed types, never primitives
+JSON serialization is `NON_NULL` (`rpc-common/.../util/JsonUtils.java:24-26`):
+null fields are **omitted**. Primitives can't be null and serialize as `0`/`false`,
+destroying the "absent vs zero" distinction.
+
+```java
+public class Book {            // Book.java:10-17
+    Integer id; Float lng; Float lat;   // boxed, not int/float
+}
+```
+- **DO:** `Integer/Long/Boolean/Float/Double` for all scalar DTO fields.
+- **DON'T:** `int/long/boolean` — loses null semantics, breaks convention.
+
+### Type avoidance
+- **Avoid `Map`** in responses (functional tests only; not for production —
+  `DemoService.java:41`).
+- **Avoid `enum`** in response DTOs — adding/removing values breaks old clients
+  (`README:87`).
+- **`byte[]`** is the one type passed bare on the wire, but **TS/Dart clients
+  cannot send `byte[]` as input** (`DemoService.java:33`).
+- Generic DTOs are supported (`PagedQuery<T>`, `PagedList<T>`, `List<T>`); the
+  server resolves type args by reflection on the method signature.
+
+### Deserialization is lenient
+`FAIL_ON_UNKNOWN_PROPERTIES=false` — extra fields from clients are tolerated
+(forward compatibility). `JavaTimeModule` auto-registers if jsr310 is present.
+
+---
+
+## 5. @RpcService and service naming
+
+`@RpcService` on the **interface** (`rpc-api/.../annotation/RpcService.java`).
+Attributes: `value` (override name), `version`, `description`, `expireSeconds`.
+
+Name derivation (`RefUtils.java:126-151`):
+- strip leading `I`: `IDemoService` → `Demo`
+- strip `Service`/`Rpc` suffix: `DemoService` → `Demo`, `FooRpc` → `Foo`
+- full name = `appName/ServiceName` (e.g. `test-server/Demo`)
+- **no dots** allowed in a service name
+
+Call path is `app/Service/method`.
+
+---
+
+## 6. @UnsafeWeb — web exposure + hiding
+
+`@UnsafeWeb` (TYPE-level, `rpc-api/.../annotation/UnsafeWeb.java`) marks a service
+**reachable directly by browsers/frontend**. Without it, the service name is
+prefixed with `-` (`HIDDEN_SERVICE`, `RefUtils.java:124-150`) so the HTTP gateway
+keeps it service-to-service only.
+
+```java
+@UnsafeWeb                              // frontend-reachable
+@UnsafeWeb(requireCredential = true)    // + JWT required for all methods
+@UnsafeWeb.RequireCredential            // method-level JWT requirement
+```
+Credential precedence: method `@RequireCredential` > class `requireCredential` >
+default false (`UnaryMethod.java:58-64`). When required, `ctx.checkCredential()`
+runs and throws (hard) on failure.
+
+- **DO:** add `@UnsafeWeb` only to services the frontend must call directly.
+- **DON'T:** add it to internal services (exposes them publicly). The name
+  "Unsafe" is a reminder that **you** own the security hardening.
+
+---
+
+## 7. Validation
+
+Uses **`jakarta.validation`** (not `javax.validation` — only the `jakarta`
+prefix is scanned, `RefUtils.java:158-175`). A validator is attached only when a
+DTO has constraint annotations; failures throw `INVALID_ARGUMENT` (hard,
+`ValidatorInvoke.java:31-44`).
+
+```java
+public class PagedQuery<Q> {                 // PagedQuery.java:28-36
+    @NotNull @Min(1) Integer page;
+    @Valid Q q;                              // @Valid cascades to nested DTOs
+}
+```
+- **DO:** annotate with `jakarta.validation` constraints; add `@Valid` for nested
+  cascade.
+
+---
+
+## 8. Authentication / context
+
+Built-in auth **verifies** an incoming JWT against a remote **JWKS** endpoint (the
+`uid()` path, once per authenticated request — `Es256Jwk.isValid`). krpc does **not
+issue** tokens while serving RPCs: minting the ES256 JWT and publishing the matching
+EC public JWKS at `rpc.server.jwks` is your **login service's** job (krpc ships
+`Es256Jws`/`Es256Signature` for the signing side if you want it). The recipe below is
+the standard "require login" (verify) side — follow it verbatim.
+
+### 8.1 Require login on a service
+
+Credential precedence: method `@RequireCredential` > class `requireCredential` >
+default false (`UnaryMethod.java:59-65`). When required, `ctx.checkCredential()`
+runs before the method and throws (hard) on failure (`UnaryMethod.java:197-199,227-229`).
+
+```java
+@UnsafeWeb(requireCredential = true)     // JWT required for every method
+public interface AccountService { ... }
+
+// or per-method:
+@UnsafeWeb
+public interface AccountService {
+    @UnsafeWeb.RequireCredential          // JWT required for this method only
+    AccountInfo me();
+}
+```
+
+### 8.2 Configure JWKS
+
+```properties
+rpc.server.jwks=<your-jwks-base-url>
+```
+Read by both `rpc-server-spring` and `rpc-server-quarkus`
+(`InitJwsVerify.java:27,30`). If the URL does not end in `.json`, krpc appends
+`.well-known/jwks.json` automatically (`JwsVerify.java:32,62-64`) — so configure the
+base URL, not the full document path. No JWKS set → auth check is skipped entirely
+(`InitJwsVerify.java:56-58` / spring `:51-54`).
+
+### 8.3 ES256 / EC keys only (silent-failure trap)
+
+`loadJwks` loads **only keys with `kty == "EC"`** and ignores everything else with
+**no error** (`JwsVerify.java:90-95`). RS256/RSA keys in the JWKS are silently
+dropped; tokens signed with them later fail with `kid not found`
+(`JwsVerify.java:127-129`). Verification is hard-wired to `SHA256withECDSA` /
+`ES256` (`Es256Jwk.java:35,37,98-106`).
+
+- **DON'T:** publish an RSA/RS256 JWKS and expect it to work — it fails silently at
+  load, loudly at verify.
+- **DO:** sign tokens with ES256 and publish EC (P-256/384/521) keys
+  (`Es256Jwk.java:32-34`).
+
+### 8.4 Token extraction
+
+`Authorization: Bearer <jwt>` is tried first; if absent, the cookie named
+`access-token` (`JwsVerify.DEFAULT_COOKIE_NAME`, `JwsVerify.java:33`;
+extraction `CredentialVerify.java:34-59`; selection `ServerContext.java:125-131`).
+The cookie name is configurable via `rpc.server.jwsCookie`
+(`InitJwsVerify.java:31,42` quarkus / `:28,39` spring).
+
+### 8.5 Reading the user in an impl
+
+```java
+public AccountInfo me() {
+    String userId = ServerContext.current().uid();   // JWT sub
+    return load(userId);
+}
+```
+
+- `ctx.uid()` — returns the JWT `sub`; throws (NPE) if not authenticated, so use
+  only on `requireCredential` endpoints (`ServerContext.java:161-163`).
+- `ctx.softUid()` — returns the `sub` or `null` when not logged in; never throws on
+  missing/invalid token (`ServerContext.java:142-155`).
+
+### 8.6 Key rotation
+
+An unknown `kid` triggers a JWKS refetch (`JwsVerify.java:71-78`), so adding a new
+key to the published JWKS rotates it in — **but** `loadJwks` is throttled to once
+per 5 minutes (`GAP_MILL`, `JwsVerify.java:35,84-86`), so a freshly added `kid` may
+not be picked up until that window elapses.
+
+### 8.7 Production hardening
+
+```properties
+rpc.server.exitOnJwksError=true
+```
+By default a bad/unreachable JWKS URL only logs a warning and leaves auth
+**disabled** (`InitJwsVerify.java:81-87` quarkus / `:76-82` spring) — requests pass
+without a credential check. Set `exitOnJwksError=true` so startup fails loudly
+instead of silently shipping with auth off.
+
+- **DO:** set `exitOnJwksError=true` in prod.
+- **DON'T:** rely on the default in prod — a JWKS outage at boot silently turns
+  authentication off.
+
+---
+
+## 9. Other authoring annotations
+
+- **`@Doc`** (`Doc.java`) — TYPE/FIELD/METHOD docs fed into generated clients;
+  `hidden=true` omits from clients; nested `@ErrorCode` documents business codes.
+- **`@Cached`** (`Cached.java`) — client-side cache by `expireSeconds` (method >
+  `@RpcService.expireSeconds` > manager default); **only `code==OK` results are
+  cached** (`MethodCallProxyHandler.java:148`).
+
+---
+
+## 10. Service implementation
+
+Implement the interface (optionally via an `AbstractXxxService` base for shared
+defaults). Container wiring:
+
+- **Quarkus:** `@ApplicationScoped @Startup` (`DemoServiceImpl.java:19-22`).
+- **Spring:** see `rpc-server-spring`.
+
+The gRPC/Netty server executor runs on **virtual threads** (one named virtual
+thread per RPC, `rpc-server/.../exe/ThreadPool.java`; JDK 21 / ADR-0002) —
+handlers may block on IO freely; don't add your own bounded RPC thread pool.
+
+---
+
+## 11. Wire / JSON / tracing (mostly automatic)
+
+- Wire envelope `OutputProto` uses single-letter fields `c`(code)/`m`(msg)/`bs`(bytes);
+  null `msg`/`data` are not written (`ServerResult.java:30-38`).
+- Trace propagation is automatic and uses **W3C Trace Context** (ADR-0003):
+  the server reads the inbound `traceparent` header into MDC (parsing
+  `traceId`/`spanId` for the log pattern) and carries `tracestate` + `x-request-id`;
+  the client forwards `traceparent` opaquely on outbound calls
+  (`TraceMeta.java`, `ServerContext.java`, `MethodCallProxyHandler.java`,
+  `PropagateTraceCall.java`). The framework propagates context, it does not start
+  spans. B3 (`x-b3-*`) is no longer emitted or read — a wire change vs 1.0.0;
+  sibling clients must adopt W3C for cross-service trace continuity.
+
+---
+
+## 12. Build, test, release
+
+```bash
+./gradlew clean build -x test    # -x test: integration tests need an internal
+                                 # MySQL host absent in clean envs and will hang
+./gradlew allDeps
+```
+JDK 21 baseline; pinned Gradle wrapper 8.14.5. When you skip tests, say so and
+list what was not validated.
+
+Native (container build, Mandrel/JDK 25):
+```bash
+./gradlew :test-server:build -Dquarkus.native.enabled=true \
+  -Dquarkus.native.container-build=true \
+  -Dquarkus.native.builder-image=quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:jdk-25 \
+  -Dquarkus.package.jar.enabled=false -x test
+```
+
+Release to Maven Central (group `tech.krpc`; credentials in
+`~/.gradle/gradle.properties`, never in the repo):
+```bash
+GRADLE_CMD=./gradlew gradle/publish-central.sh upload        # build+sign+upload, wait VALIDATED (reversible)
+GRADLE_CMD=./gradlew gradle/publish-central.sh publish --yes  # IRREVERSIBLE — cannot be deleted/overwritten
+```
+Set `version` + `changelog.md` first; `ext-rpc-gen` (group `tech.krpc.ext`) is
+released on its own cycle, not in the krpc bundle. Tag `vX.Y.Z` and cut the
+GitHub release after Central publish succeeds.
+
+---
+
+## 13. Native image (GraalVM)
+
+Single source of truth for building krpc services as native images — humans and
+agents read the same section. Consumer-proven 2026-06 on 8 downstream Quarkus
+3.33.2 services (boot-to-ready 0.028s native). Items tagged `[gap → NATIVE-00x]`
+are framework defects with roadmap items: apply the workaround now, delete it
+when the item completes.
+
+### 13.1 io.grpc version alignment — Quarkus LTS support matrix
+
+krpc tracks the Quarkus LTS BOM's io.grpc version (Option A, ADR NATIVE-001).
+`gradle.properties` pins `grpcVersion` to what the supported Quarkus LTS ships, so
+a Quarkus consumer's highest-wins resolution converges on a single io.grpc — no
+consumer-side force, and native-image's `Target_io_grpc_ServiceProviders`
+substitution matches the class shape.
+
+| krpc release                    | Quarkus LTS | io.grpc | consumer force |
+|---------------------------------|-------------|---------|----------------|
+| ≥ 1.0.3 (this alignment)        | 3.33.x LTS  | 1.79.0  | none — aligned |
+| published ≤ 1.0.2               | 3.33.x LTS  | 1.82.0  | required (below) |
+
+(Bump `grpcVersion` in lockstep when adopting the next Quarkus LTS.)
+
+**For published krpc ≤1.0.2 only** (ships io.grpc 1.82.0, skewed above the BOM → native-image
+aborts during Initializing): force `io.grpc:*` back to the BOM version in the root
+build — `configurations.all { resolutionStrategy.eachDependency { if (it.requested.group == 'io.grpc') it.useVersion '1.79.0' } }`.
+
+### 13.2 Server-side native support — use `ext-rpc` ≥ 1.0.2 (NATIVE-002, shipped)
+
+Since `tech.krpc.ext:ext-rpc` **1.0.2**, the Quarkus extension registers everything a
+native SERVER needs with zero per-service glue: the deployment processor emits
+reflective registration for the grpc provider impls and a build-time GraalVM
+`Feature` that bakes `io.grpc.ServerProvider.provider()` into the image heap
+(krpc itself only covers the client side —
+`rpc-client/.../ext/GraalvmBuild.java:14-18`). It also gates its grpc-netty
+substitutions on `quarkus-grpc-common` absence, so they no longer collide with
+Quarkus's own.
+
+**On `ext-rpc` ≤ 1.0.1 only**, a native server dies at boot with
+`ManagedChannelProvider$ProviderNotFoundException: No functional server found`
+and duplicate-substitution aborts; either upgrade, or apply the legacy trio
+(per-service `ServerProvider` Feature + `@RegisterForReflection` provider holder +
+`quarkus.class-loading.removed-resources` strip) — recipe preserved in the
+`v1.0.3` tag of this file and in `ext-rpc` PR #2.
+
+### 13.3 Build recipe and known runtime issues
+
+- Build command: [§12](#12-build-test-release). Native needs
+  `-Dquarkus.package.jar.enabled=false` (Gradle can't output both), and the
+  builder image must match your Quarkus/JDK line — for the JDK 21 baseline use
+  `quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:jdk-21` (krpc's own
+  test-server was additionally validated on Mandrel 25 / jdk-25).
+- Static-heap violations are per-service: any `static final` SecureRandom /
+  Random / network-touching singleton fails analysis; fix with
+  `--initialize-at-run-time=<class>` (the native build error names the class).
+- Known issue: a native runner **SIGSEGVs at startup when datasource env/config
+  is absent** (logs "started", then exit 139). Ensure `QUARKUS_DATASOURCE_*` is
+  set; JVM mode fails gracefully, native does not.
+
+### 13.4 io_uring transport (evaluated 2026-07)
+
+Status: evaluated. A flag-gated PoC exists on eval branch `feat/iouring-eval` —
+**not shipped; the default transport stays NIO in native / epoll-or-NIO on JVM.**
+
+- **Netty artifact constraint.** Today's stack (Quarkus 3.33 LTS = Netty 4.1) can
+  only use the ARCHIVED incubator artifact
+  (`io.netty.incubator:netty-incubator-transport-native-io_uring:0.0.26.Final`).
+  The graduated transport (`io.netty.channel.uring`) is Netty-4.2-only, which
+  arrives with Quarkus 4 / Vert.x 5.
+- **Native-image: works.** Flag `KRPC_IOURING`, hand-authored JNI/reflect/resource
+  metadata, `--initialize-at-run-time`; +0.56 MiB image, +1.9 MiB RSS.
+- **Benchmark verdict (aarch64, containerized): 5–6% SLOWER than NIO** on krpc's
+  typical small-message unary path. io_uring's win case (many connections,
+  syscall-bound) is not this profile. Details:
+  workspace `docs/orchestration/IOURING-001_{RESEARCH,BENCH}_omp.md`.
+- **Ops note.** Docker's default seccomp profile blocks io_uring syscalls
+  (`io_uring_setup` → EPERM); running the flag ON in containers needs an allowing
+  seccomp profile.
+
+### 13.5 Reflection coverage (what the framework registers for you)
+
+Native is closed-world: the framework registers reflection at build time, but
+only for what its build-time scan can reach. Know what is and is not covered.
+
+- **The extensions must be on the native build.** DTO reflection is registered by
+  the `ext-rpc` Quarkus deployment processor: it indexes every `@RpcService`
+  interface (Jandex), walks each method's param + return types, and emits
+  `ReflectiveClassBuildItem` for the DTOs with `methods(true).fields(true)`
+  (`ext-rpc/ext-rpc-deployment/.../RpcProcessor.java:75-94,148-150`). `ext-mybatis`
+  does the equivalent for its mapper/entity types. Drop the extension and **nobody**
+  registers your DTOs — they reflect fine on JVM but fail at native runtime.
+- **Nested DTOs are auto-covered only 8 levels deep.** After the top-level DTOs, the
+  processor recurses through nested field types up to `max_level = 8`
+  (`RpcProcessor.java:158-170`); beyond that it logs `TOO DEEP Nest Dto`
+  (`:180`) and stops registering. Keep DTO nesting shallow, or register deeper types
+  by hand.
+- **Third-party bean types are not scanned.** The recursion explicitly skips `java.*`
+  types (`RpcProcessor.java:225`) and only follows types reachable from your own
+  DTO fields — an external-library class referenced by a DTO is outside the scan and
+  will throw at native runtime. Register it yourself with Quarkus's
+  `@RegisterForReflection` (`io.quarkus.runtime.annotations.RegisterForReflection`),
+  e.g. on an aggregate class:
+
+  ```java
+  import io.quarkus.runtime.annotations.RegisterForReflection;
+
+  @RegisterForReflection(targets = { com.vendor.lib.Foo.class, com.vendor.lib.Bar.class })
+  public final class NativeReflectionConfig {}
+  ```
+
+  Or add the class to a `META-INF/native-image/<group>/reflection-config.json`.
+- **Framework classes are already registered — don't re-register them.** krpc's own
+  runtime types ship reflection metadata in each module's
+  `META-INF/native-image/*/reflection-config.json` + `native-image.properties`
+  (`rpc-api/...`, `rpc-common/...`, `rpc-client/...`,
+  `rpc-server-quarkus/src/main/resources/META-INF/native-image/rpc-server/...`).
+  You only own the third-party types your DTOs pull in.
+
+### 13.6 Native checklist for a consumer service
+
+- [ ] **krpc ≤1.0.2 only:** `io.grpc:*` forced to the Quarkus BOM version (root build) — §13.1. (krpc >1.0.2 is aligned; skip.)
+- [ ] `ext-rpc` ≥ 1.0.2 on the build (server-side native support; ≤1.0.1 needs the legacy trio) — §13.2.
+- [ ] Builder image matches Quarkus/JDK line; `package.jar.enabled=false` — §13.3.
+- [ ] Per-service `--initialize-at-run-time` for static-heap violations — §13.3.
+- [ ] Datasource config present at runtime (SIGSEGV otherwise) — §13.3.
+- [ ] `ext-rpc` / `ext-mybatis` extensions on the build (DTO reflection) — §13.5.
+
+---
+
+## 14. Quick checklist for a new service
+
+- [ ] Interface annotated `@RpcService`; name has no dots.
+- [ ] Every method `RpcResult<Dto> m(OneDto)` or `m()` — never 2+ params, never raw return.
+- [ ] DTO scalar fields are boxed types; no `Map`/`enum` in responses.
+- [ ] Business failures → `RpcResult.error(code>0, msg)` with hundreds/thousands codes; system/security → throw.
+- [ ] `@UnsafeWeb` only if frontend-facing; `requireCredential` where auth is needed.
+- [ ] `jakarta.validation` constraints (+ `@Valid` for nesting) where input must be checked.
+- [ ] `ctx.uid()` / `ctx.softUid()` for the user; don't hand-roll trace propagation.
+
+---
+
+**Source of truth:** ADRs (`docs/decisions/`) > module docs (`docs/modules/`,
+`FOR`/`NOT FOR`) > module evolution > roadmap (`docs/roadmap/active-roadmap.md`)
+> inline TODOs. Index: `docs/INDEX.md`. Governance: `AGENTS.md`.


### PR DESCRIPTION
## Summary (7 commits, STRAT-001 R2 rec#1 approved; docs-only, zero Java/gradle/publish changes — verified by review)
- **Official krpc agent skill** (`skills/krpc/SKILL.md`): portable tool-agnostic text for coding agents working in krpc consumer projects — 5-rule quick reference (verified verbatim against SPEC §1–§6, incl. the byte[] bare-wire exception), P0 discover→invoke curl templates, native pointers. README/docs-site install pointers.
- **`llms.txt`** at repo root + docs-site static (llmstxt.org format, 12 links validated).
- **Agent guide** (`docs/agent-guide.md`): how agents discover/invoke krpc services — with REAL curl transcripts against the quickstart, honest auth semantics (Authorization-only on the agent path; rejection depends on JWKS config), `agentTool` labeled accepted-not-built (ADR-0004).
- **Roadmap caveat**: AGENT-001 P0 endpoints are unreachable in default Quarkus apps — Arc `remove-unused-beans` removes the reflectively-discovered handlers (repro: `-Dquarkus.arc.remove-unused-beans=none`). Fix folded into Wave 3 (P1 thin MCP bridge prerequisite).

## Review
codex r1 REQUEST-CHANGES (credential-wording overclaim) → r2 REQUEST-CHANGES (NEW: cookie-forwarding claim false on agent path — `AgentInvokeHandler` copies Authorization only) → fixes → **r3 PASS** (ledger complete, zero .java diff verified).

## Found along the way (queued for Wave 3)
P0 Arc bean-removal fix · `AgentInvokeHandler` comment nit (404 vs code 5) · container-level test gap (`@QuarkusTest`) · cookie support on agent path = product decision.