### PR TITLE
docs(spec): clarify root SPEC.md vs skill-bundled mirror

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1,5 +1,10 @@
 # KRPC Development Spec
 
+<!-- CANONICAL. This root SPEC.md is the source of truth. A byte-identical copy is
+     bundled at skills/krpc/references/SPEC.md so the `krpc` agent skill stays
+     self-contained when copied into a consumer project — edit THIS file; CI
+     (.github/workflows/skill-sync.yml) fails if the mirror drifts. -->
+
 A tool-agnostic handbook for any coding agent (Claude, Codex, …) **writing or
 calling KRPC services**. It encodes the framework's authoring conventions with
 code evidence (`file:line`). Governance/architecture authority lives in

--- a/skills/krpc/references/SPEC.md
+++ b/skills/krpc/references/SPEC.md
@@ -1,5 +1,10 @@
 # KRPC Development Spec
 
+<!-- CANONICAL. This root SPEC.md is the source of truth. A byte-identical copy is
+     bundled at skills/krpc/references/SPEC.md so the `krpc` agent skill stays
+     self-contained when copied into a consumer project — edit THIS file; CI
+     (.github/workflows/skill-sync.yml) fails if the mirror drifts. -->
+
 A tool-agnostic handbook for any coding agent (Claude, Codex, …) **writing or
 calling KRPC services**. It encodes the framework's authoring conventions with
 code evidence (`file:line`). Governance/architecture authority lives in


### PR DESCRIPTION
Adds a one-line comment at the top of SPEC.md explaining why there are two copies: the root is canonical, `skills/krpc/references/SPEC.md` is a byte-identical mirror bundled so the krpc agent skill is self-contained when copied into a consumer project, and CI (`skill-sync.yml`) fails on drift. No content change; mirror re-synced byte-identical. (Addresses the 'why two SPEC.md?' question — root stays the SoT, no broken links / no doc-site 404s.)