### PR TITLE
feat(otel): OTel span creation on krpc gRPC + HTTP faces (OTEL-001, ADR-0006)

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -8,6 +8,7 @@ This index maps the repository source of truth for KRPC.
 - [ADR-0002: JDK 21 And Virtual Threads](decisions/ADR-0002-jdk21-virtual-threads.md)
 - [ADR-0003: W3C Trace Context Propagation](decisions/ADR-0003-w3c-trace-context.md)
 - [ADR-0004: Agent-Friendly Introspection And MCP Surface](decisions/ADR-0004-agent-friendly-introspection.md)
+- [ADR-0006: OpenTelemetry Span Creation In The Framework](decisions/ADR-0006-otel-span-creation.md)
 
 ## Modules
 
@@ -43,4 +44,5 @@ This index maps the repository source of truth for KRPC.
 | Framework, native-image, gateway, and tooling integrations | `rpc-client-spring`, `rpc-server-spring`, `rpc-server-quarkus`, `http-server`, `rpcurl`, `test-rpc-gen` | ADR-0001 | GOV-001 |
 | JDK 21 baseline and virtual-thread runtime feature | `rpc-server`, `rpc-client`, `http-server`, integration modules | ADR-0002 | N/A |
 | Agent-friendly introspection (HTTP discover→call, runtime MCP surface) | `rpc-common`, `rpc-server`, `rpc-client`, `http-server`, `rpc-api` | ADR-0004 | AGENT-001 |
+| Distributed-trace span creation + W3C context on KRPC faces (gRPC + HTTP) | `rpc-common`, `rpc-server`, `rpc-client`, `http-server` | ADR-0006 (amends ADR-0003) | OTEL-001 |
 | Quarkus native-image consumer path (grpc alignment, provider registration) | `gradle.properties`, `rpc-server-quarkus`, `SPEC.md` §13 (+ `ext-rpc`, workspace NATIVE-002) | N/A | NATIVE-001 |

--- a/docs/decisions/ADR-0003-w3c-trace-context.md
+++ b/docs/decisions/ADR-0003-w3c-trace-context.md
@@ -2,6 +2,12 @@
 
 Status: accepted
 
+Amended by: ADR-0006 (2026-07-16). ADR-0006 supersedes the "the framework creates no spans"
+clause below (span creation now joins the framework via the OTel API). The W3C propagation
+decision in this ADR — single `traceparent`/`tracestate`, drop B3, forward `x-request-id` — still
+stands, and the MDC forwarding path continues to coexist with span creation (one `traceparent` on
+the wire; see ADR-0006 "Coexistence with ADR-0003 MDC forwarding").
+
 Date: 2026-06-20
 
 ## Context
@@ -33,7 +39,8 @@ KRPC propagates trace context using W3C Trace Context:
 Behavior remains pure propagation: the server parses the inbound `traceparent`,
 exposes `traceId` / `spanId` to the log layout via MDC, and the client forwards the
 unchanged `traceparent` (plus `tracestate` / `x-request-id`) on outbound calls. The
-framework still creates no spans.
+framework still creates no spans. <!-- Superseded by ADR-0006: the framework now creates
+SERVER/CLIENT spans via the OTel API; this MDC forwarding coexists (one traceparent on the wire). -->
 
 ## Consequences
 

--- a/docs/decisions/ADR-0006-otel-span-creation.md
+++ b/docs/decisions/ADR-0006-otel-span-creation.md
@@ -1,0 +1,140 @@
+# ADR-0006: OpenTelemetry Span Creation In The Framework
+
+Status: accepted
+
+Date: 2026-07-16
+
+Amends: ADR-0003 (supersedes its "the framework creates no spans" clause; ADR-0003's W3C
+propagation decision otherwise stands).
+
+## Context
+
+KRPC runs on self-owned Netty faces: gRPC rides grpc-java's `io.grpc.netty.NettyServerHandler`
+(not `quarkus-grpc`), and HTTP rides KRPC's own `AbstractHttpHandler`. A consumer whose OTLP
+pipeline is fully provisioned (OTel SDK + exporter on the classpath, endpoint configured) still
+gets **zero traces from KRPC calls**, because Quarkus auto-instrumentation only wraps the faces it
+owns — it never sees KRPC's transports. The missing layer is **span creation + inbound context
+extraction** at KRPC's three entry/exit points.
+
+ADR-0003 moved propagation to W3C Trace Context but deliberately stopped at pure forwarding: the
+server parses the inbound `traceparent` into MDC (`traceId`/`spanId` for the log layout) and the
+client forwards the unchanged `traceparent` on outbound calls. No spans were created, so there is
+nothing to connect the inbound and outbound context into a real per-call trace tree.
+
+ADR-0001 / North-Star NS-3 keep telemetry **backends** out of core (Kubernetes / Istio / the
+consumer's Quarkus stack own them). The OpenTelemetry **API + instrumentation** is not a backend —
+it is the integration seam. The SDK and exporter remain consumer-side.
+
+## Decision
+
+The framework creates spans, using the **OpenTelemetry API only**. Three instrumentation points:
+
+1. **`OtelServerInterceptor`** (`rpc-server`, registered via `ServerBuilder.intercept`): extracts
+   the inbound W3C context from the call metadata, starts a `SERVER` span (rpc semantic
+   conventions: `rpc.system=grpc`, `rpc.service`, `rpc.method`, `rpc.grpc.status_code`), and makes
+   it current on every listener callback — including `onHalfClose`, where KRPC runs the handler on
+   the app executor (a virtual thread; ADR-0002). The handler and any outbound call it makes see
+   the SERVER span as their current context.
+2. **`OtelClientInterceptor`** (`rpc-client`, installed on the channel in `MethodCallProxyHandler`):
+   starts a `CLIENT` span (child of the current context — the SERVER span when the call originates
+   inside a handler) and injects `traceparent` into the outbound metadata.
+3. **HTTP handler** (`http-server`, `AbstractHttpHandler`): extracts the inbound W3C context from
+   the request headers (webhook/callback entry) and starts a `SERVER` span around `handle(...)`,
+   current on the handler's virtual thread.
+
+### API-only, hand-rolled (not `opentelemetry-grpc-1.6`)
+
+Core depends on exactly one new artifact: `io.opentelemetry:opentelemetry-api` (which pulls only
+`opentelemetry-context`). We hand-roll the interceptors on that API instead of adopting the
+`io.opentelemetry.instrumentation:opentelemetry-grpc-1.6` library because:
+
+- **NS-3 minimalism.** The instrumentation library is `-alpha` and pulls `instrumentation-api`,
+  `instrumentation-api-incubator`, and `opentelemetry-semconv` into core. The RPC protocol surface
+  is small (extract → start span → scope → inject → end); hand-rolling keeps core to a single
+  stable API dependency and no alpha/incubator surface.
+- **NS-7 native-image.** Fewer, non-alpha classes with no muzzle/bytecode machinery; rpc semantic
+  attribute names are hardcoded (`KrpcOtel`) rather than pulled from the alpha semconv artifact.
+- **Control over the ADR-0003 coexistence** (below), which the off-the-shelf interceptor does not
+  give us.
+
+### Explicit injection — never the JVM-global accessor
+
+Core holds a `volatile OpenTelemetry` in `KrpcOtel`, `OpenTelemetry.noop()` until an integration
+explicitly calls `KrpcOtel.install(OpenTelemetry)`. Core **never** reads the JVM-global
+`OpenTelemetry` accessor. That was the original design and it is a landmine: on first read when
+unset, the accessor does a synchronized init that (a) probes for an autoconfigure SDK via
+`Class.forName` and, absent one, **pins the JVM-global to a no-op** — so any krpc call that arrives
+before the consumer registers its SDK would permanently disable tracing AND break the consumer's own
+later `buildAndRegisterGlobal()` (which throws once the global is set); or (b) with autoconfigure on
+the classpath, reflectively boots an SDK we never asked for. Either way, reading the global from a
+library on the hot path is wrong.
+
+Wiring:
+
+- **Quarkus** (`rpc-server-quarkus`): `RpcServiceExpose` (`@Startup`) injects an optional
+  `Instance<OpenTelemetry>` and calls `install(...)` when resolvable; absent → stays no-op. `@Startup`
+  runs after the container is initialized, so the bean (when the consumer ships `quarkus-opentelemetry`)
+  is available. **Verified**: `examples:quickstart`'s `OtelServerSpanQuarkusTest` boots a real
+  Quarkus app with `quarkus-opentelemetry` (test scope), asserts the bean is resolvable + `install`
+  ran (`KrpcOtel.isNoop()==false`), and a real gRPC call exports a SERVER span. The only deferred
+  check is full OTLP export to a real backend (consumer/iac concern, not core).
+- **Spring** (`rpc-server-spring` `RpcServiceExposer#onApplicationEvent`, `rpc-client-spring`
+  `RpcClientAutoConfigure#afterPropertiesSet`): install the context's `OpenTelemetry` bean via
+  `ObjectProvider`/`getBeanProvider(...).ifAvailable(...)`; absent → stays no-op.
+- **Plain netty** (no DI): the consumer calls `KrpcOtel.install(openTelemetry)` explicitly at
+  startup. No ambient magic, no global pinning.
+
+### Default-ON kill switch
+
+A flag `rpc.otel.enabled` (system property) / `KRPC_OTEL` (env) gates registration; default **ON**.
+Default-ON is safe: until an SDK is installed, `KrpcOtel` is a no-op — the tracer returns invalid
+spans, the propagator injects/extracts nothing. Combined with the fast path below, a no-SDK consumer
+sees **zero spans, zero header changes, zero cost beyond one volatile read + a reference compare per
+call** (NS-4: byte-identical wire). The flag is resolved once at registration, so `KRPC_OTEL=false`
+makes the interceptors byte-level absent (not even the volatile read).
+
+### No-op fast path (per-call, allocation-free)
+
+Each interceptor first checks `KrpcOtel.isNoop()` — a single `volatile` read of the installed
+`OpenTelemetry` and a reference compare against the `OpenTelemetry.noop()` singleton, no allocation —
+and short-circuits: the server interceptor returns `next.startCall(call, headers)` unwrapped, the
+client interceptor returns `next.newCall(...)` unwrapped, and the HTTP handler skips
+extraction/span/scope entirely. So the no-SDK path allocates nothing from OTel and leaves the call
+untouched (no no-op span, no `Context.with`, no `Scope`, no listener wrappers).
+
+The check is **per-call, not a build-time snapshot**, and it reads krpc's own volatile — never the
+JVM global. Install ordering therefore does not matter and cannot corrupt anything: a call before
+`install(...)` reads `noop()` and is an untraced no-op; a call after reads the installed SDK and
+traces. If the SDK is installed after the very first calls, those early calls are untraced — an
+unavoidable, negligible window; steady state traces correctly.
+
+### Coexistence with ADR-0003 MDC forwarding
+
+ADR-0003's MDC path is unchanged: the server still parses `traceparent` into MDC for the log
+layout, and `PropagateTraceCall` still forwards the inbound `traceparent` verbatim on outbound
+calls. The invariant is **exactly one `traceparent` on the wire in every mode**, enforced by
+`KrpcOtel.METADATA_SETTER`, which *overwrites* (removeAll + put):
+
+- **No SDK:** the OTel propagator is a no-op and injects nothing, so the MDC-forwarded
+  `traceparent` survives unchanged — identical to pre-ADR-0006 behavior.
+- **SDK present:** the client interceptor injects a fresh `traceparent` for the CLIENT span; the
+  overwriting setter makes it supersede the MDC-forwarded (parent-level) value, so the downstream
+  sees the correct new parent — still one header.
+
+This is the clause of ADR-0003 that ADR-0006 amends: "the framework still creates no spans" no
+longer holds. ADR-0003's decision to use W3C `traceparent`/`tracestate`, drop B3, and forward
+`x-request-id` is untouched.
+
+## Consequences
+
+- **NS-3 intact.** No OTel SDK/exporter/backend in any core module's runtime classpath — only
+  `opentelemetry-api` + `opentelemetry-context`. The SDK arrives from the consumer's Quarkus stack.
+- **NS-4 intact.** No wire-format change: only `traceparent`/`tracestate` headers, and only when an
+  SDK is active. A no-OTel-SDK consumer's wire is byte-identical.
+- **NS-7.** No new open-world reflection; the API classes carry no reflection/config needs of their
+  own (SDK native config is the consumer's Quarkus concern).
+- **Consumers with a Quarkus OTel stack** now get connected traces across KRPC gRPC and HTTP hops
+  with no application code — the gap that produced "OTLP provisioned, zero traces" is closed.
+- **Version.** `opentelemetry-api` is pinned to the OTel SDK version shipped by the Quarkus 3.33
+  LTS BOM (1.49.0) for zero compile/runtime skew. It is a plain `api` dependency, not a published
+  platform constraint, so a consumer's BOM still wins the transitive version.

--- a/docs/orchestration/OTEL-001_IMPL_omp.md
+++ b/docs/orchestration/OTEL-001_IMPL_omp.md
@@ -1,0 +1,267 @@
+# OTEL-001 — OTel Span Creation On KRPC Faces (Implementation Findings)
+
+Owner: omp. Branch `feat/otel-interceptors` (from origin/dev @ 049e8ff). ADR-0006.
+Date: 2026-07-16.
+
+## What changed
+
+Span creation joins the framework at KRPC's three self-owned faces, using the OpenTelemetry
+**API only** (no SDK/exporter in core; ADR-0001 / NS-3).
+
+| Area | File | Change |
+| --- | --- | --- |
+| Shared | `rpc-common/.../context/KrpcOtel.java` (new) | Flag (`rpc.otel.enabled`/`KRPC_OTEL`), `volatile OpenTelemetry` + `install(...)` (no global probing), installed-OTel tracer/propagator, gRPC `Metadata` getter/**overwriting** setter, rpc/http attribute keys. |
+| gRPC server | `rpc-server/.../OtelServerInterceptor.java` (new) | Extract inbound W3C ctx → `SERVER` span → made current on every listener callback (incl. `onHalfClose`, where the handler runs on a virtual thread). |
+| gRPC server wiring | `rpc-server/.../RpcServerBuilder.java` | `serverBuilder.intercept(new OtelServerInterceptor())` when enabled. |
+| gRPC client | `rpc-client/.../OtelClientInterceptor.java` (new) | `CLIENT` span (child of current ctx) + W3C `traceparent` injection. |
+| gRPC client wiring | `rpc-client/.../MethodCallProxyHandler.java` | Channel wrapped via `ClientInterceptors.intercept` when enabled; field widened `ManagedChannel`→`Channel`. |
+| HTTP | `http-server/.../AbstractHttpHandler.java` | Extract W3C ctx from request headers → `SERVER` span around `handle(...)`, current on the handler's virtual thread. |
+| Deps | `gradle.properties`, `rpc-common/build.gradle` | `otelVersion=1.49.0`; `api io.opentelemetry:opentelemetry-api` in rpc-common (transitive to server/client/http). |
+| Docs | `ADR-0006` (new), `ADR-0003` (amended), `active-roadmap.md`, `docs/INDEX.md` | See ADR/roadmap sections. |
+
+## Dependency decision (premise VERIFY)
+
+- **Claim: krpc gRPC server accepts a standard `ServerInterceptor` / client a `ClientInterceptor`
+  without forking grpc-java.** VERIFIED. Server: `ServerBuilder.intercept(...)` in
+  `RpcServerBuilder.init`. Client: `ClientInterceptors.intercept(channel, ...)` in
+  `MethodCallProxyHandler`. No grpc-java internals touched.
+- **Claim: `opentelemetry-grpc-1.6` compatible with pinned grpc/JDK 21.** N/A — **rejected in
+  favor of hand-rolling on `opentelemetry-api`**. Rationale: the instrumentation library is
+  `-alpha` and drags `instrumentation-api` + `-incubator` + `semconv` into core. The RPC surface
+  is small; hand-rolling keeps core to exactly `opentelemetry-api` (+ transitive
+  `opentelemetry-context`), both stable, native-clean. rpc semantic attribute names are hardcoded
+  in `KrpcOtel` to avoid the alpha `semconv` artifact. Resolution verified:
+  `:rpc-common:dependencies` shows `opentelemetry-api:1.49.0 -> opentelemetry-context:1.49.0` and
+  nothing else. Version pinned to the OTel SDK in the Quarkus 3.33 LTS BOM (1.49.0) for zero skew.
+- **Claim: MDC forwarding (ADR-0003) and OTel propagation coexist without duplicate/conflicting
+  headers.** VERIFIED by test (below). `KrpcOtel.METADATA_SETTER` overwrites (removeAll+put), so
+  exactly one `traceparent` on the wire in both modes.
+
+## Flag semantics
+
+- `rpc.otel.enabled` (system property) or `KRPC_OTEL` (env). Default **ON**. Explicit `false`/`0`
+  disables; property wins over env. Resolved once at class load → OFF makes interceptors
+  byte-level absent (no per-call cost).
+- Default-ON is safe: until an SDK is **installed** via `KrpcOtel.install(...)`, `KrpcOtel` is a
+  no-op — no-op tracer, no-op propagator injects/extracts nothing. Zero spans, zero header
+  changes, zero cost beyond a no-op call (NS-4 byte-identical wire). The no-op path was confirmed
+  zero-behavior by the parity test and the native no-SDK smoke — no STOP-AND-REPORT triggered.
+
+## Verified (actually run this session)
+
+All via `gradle` (9.6.0) on Oracle GraalVM 25 (tests) / GraalVM 21 (native).
+
+- **Full module suites green** (no existing test changed/skipped):
+  `rpc-common: 25 tests, 0 failures` · `rpc-client: 23, 0` · `rpc-server: 59, 0` ·
+  `http-server: 17, 0`. Total **124 tests, 0 failures**.
+- **Propagation across a real in-process hop** — `OtelPropagationHopTest`
+  (`inboundContextFlowsThroughClientAndServerSpans`, PASS): with the SDK test exporter, a root
+  (inbound) span → `blockingUnaryCall` through `OtelClientInterceptor` + `OtelServerInterceptor`
+  on a real in-process transport. Asserted and passing:
+  - one trace id across root, CLIENT, SERVER spans;
+  - parent chain root → CLIENT → SERVER (`SERVER.parentSpanId == CLIENT.spanId`,
+    `CLIENT.parentSpanId == root.spanId`) — i.e. inbound `traceparent` → server span → (its)
+    client span → outbound `traceparent`, one header, correct parents;
+  - `rpc.system=grpc`, `rpc.service=krpc.test.Echo`, `rpc.method=echo` on the SERVER span;
+  - the SERVER span is current inside the handler, which runs on a **virtual thread**.
+- **No-SDK parity** — `OtelClientMdcParityTest` (3 PASS):
+  - `noSdk_mdcTraceparent_forwardedAsSingleHeader`: no SDK + MDC `traceparent` → outbound carries
+    exactly `[<the MDC value>]` (byte-identical to pre-OTEL ADR-0003).
+  - `noSdk_noMdc_noTraceparent`: no SDK, no MDC → no `traceparent` emitted.
+  - `sdkPresent_clientSpanTraceparent_supersedesStaleMdc_singleHeader`: SDK + a *stale* MDC
+    `traceparent` → exactly one outbound `traceparent`, carrying the current trace id (not the
+    stale one), whose span id is the CLIENT span (child of the current server span). Proves the
+    overwrite-not-duplicate coexistence.
+- **HTTP SERVER span** — `HttpOtelSpanTest` (2 PASS): real `HttpServer` + `HttpClient`. Inbound
+  `traceparent` → SERVER span is its child (same trace id, `parentSpanId == inbound span id`),
+  named after the handler path, `http.response.status_code` attribute set, span current on the
+  handler's virtual thread; no inbound context → fresh root SERVER span.
+- **KrpcOtel unit** — `KrpcOtelTest` (6 PASS): flag resolver matrix (default ON; `false`/`0`
+  disables; prop wins over env) + metadata setter single-value overwrite + getter.
+- **NS-3 gate (manual)**: `gradle :<m>:dependencies --configuration runtimeClasspath | grep -i
+  opentelemetry` for `rpc-common`, `rpc-client`, `rpc-server`, `http-server`,
+  `rpc-server-quarkus` shows ONLY `opentelemetry-api:1.49.0 -> opentelemetry-context:1.49.0`. The
+  `opentelemetry-sdk|exporter|otlp` grep across all five is **empty**. No SDK/exporter in any core
+  runtime classpath.
+- **Native (NS-7)**: `examples:quickstart` native image built (GraalVM 21, host toolchain, `-x
+  test`) — **BUILD SUCCESSFUL in 1m40s**, no reflection/build errors from the OTel surface. Booted
+  the runner (`quickstart 1.1.0 native ... started in 0.027s`) and smoked: `GET /agent/discover`
+  → 200, `GET /mcp` → 405, malformed `POST /agent/invoke` → 400, and a real gRPC call via `rpcurl`
+  (`quickstart/Hello/hello`) → `code 0` with the echoed greeting — exercising the registered
+  `OtelServerInterceptor` (no-op, no SDK) on the native gRPC path with zero behavior change.
+
+## NOT verified
+
+- **Full OTLP export to a real backend** (spans leaving the process to a collector) is not run
+  locally — no OTel SDK/exporter ships in core by design (NS-3). This is now the ONLY deferred
+  item; LH's iac probe covers deployed OTLP E2E. Everything else — span creation, parentage,
+  cross-hop propagation, and the Quarkus SDK-present injection path — is proven locally (in-process
+  SDK test exporter + the `examples:quickstart` `@QuarkusTest`, see Fixround r3).
+- (r1 said no `@QuarkusTest` was added — superseded by r3, which adds the positive-injection
+  container test in `examples:quickstart`.)
+- Native run used **GraalVM 21** locally; CI uses **Mandrel 21**. Both are GraalVM-family JDK 21
+  native-image; no Mandrel-specific path was exercised locally.
+- `GeneralizeClient` (the generic rpcurl/introspection client path) is **not** instrumented — it
+  is outside the typed cross-service chain scenario and out of this goal's scope.
+
+## Remaining risks
+
+- **Span end on client cancellation**: the CLIENT span ends in `onClose`; the SERVER span ends on
+  the terminal listener event (`onComplete`/`onCancel`, guarded by an `AtomicBoolean`). Streaming
+  is not a concern (KRPC is unary). If a future non-unary path is added, the terminal-event
+  handling must be revisited.
+- **`opentelemetry-api` version drift**: pinned to 1.49.0 (Quarkus 3.33 LTS). It is a plain `api`
+  dep (not a published platform constraint), so a consumer BOM still wins the transitive version;
+  the OTel API is stable within 1.x for the surface used (OpenTelemetry, Tracer/Span/SpanKind,
+  Context/Scope, TextMap propagation, Attributes).
+- **MDC still populated in parallel** (ADR-0003) for the log layout; this is intentional and
+  tested to not double-emit `traceparent`. If MDC forwarding is ever removed, the no-SDK
+  propagation guarantee would rest solely on OTel (which is a no-op without an SDK) — do not remove
+  the MDC path without replacing that guarantee.
+
+## FOR / NOT FOR boundaries
+
+No module boundary crossed into NOT FOR. `rpc-common` gains a shared instrumentation helper (API
+only); server/client/http-server gain their own face's interceptor. No telemetry backend, registry,
+LB, or SDK entered core (ADR-0001 / NS-3 intact).
+
+## Fixround r1 (codex: 2 blocking) — resolved
+
+### B1 — no-SDK path provably free
+
+- **Short-circuit added.** Each interceptor now calls `KrpcOtel.isNoop()` first and takes a fast
+  path when no SDK is installed: `OtelServerInterceptor` returns `next.startCall(call, headers)`
+  unwrapped, `OtelClientInterceptor` returns `next.newCall(...)` unwrapped, and
+  `AbstractHttpHandler` gates the span on `OTEL_ENABLED && !isNoop()`. r1 wrapped every call and
+  allocated a no-op span + `Context` + `Scope` + listener wrappers even with no SDK; r2 allocates
+  nothing from OTel on that path.
+- **Per-call, not build-time snapshot.** `isNoop()` = `GlobalOpenTelemetry.get().getTracerProvider()
+  == TracerProvider.noop()` — an identity compare, allocation-free. Chosen per-call because Quarkus
+  installs `GlobalOpenTelemetry` during startup with no ordering guarantee vs krpc's `@Startup`
+  server/client construction; a build-time snapshot could latch "no-op" and silently disable
+  tracing. Recorded in ADR-0006 ("No-op fast path").
+- **Per-call allocation story (no SDK):** two field reads + one pointer compare per call; no object
+  allocation, no header mutation, call proceeds untouched. ADR-0003 MDC forwarding is the only
+  thing that may add a header (unchanged).
+- **Proven on a real SDK-free classpath.** New Gradle source set `rpc-server:noSdkTest` whose
+  runtimeClasspath carries `opentelemetry-api` only — no `opentelemetry-sdk`/`sdk-testing` (r1's
+  "no-SDK" test ran with sdk-testing present + `resetForTest()`, which the reviewer correctly
+  flagged as ≠ absent). `gradle :rpc-server:noSdkTest` → **7 tests, 0 failures**:
+  - `Class.forName("io.opentelemetry.sdk.OpenTelemetrySdk")` and `...InMemorySpanExporter` both
+    throw `ClassNotFoundException` (classpath really is SDK-free);
+  - `KrpcOtel.isNoop()` == true;
+  - client interceptor returns the delegate call **by identity** (unwrapped — short-circuit branch
+    observed, not timing); server interceptor returns the delegate listener **by identity** (its
+    stub `getMethodDescriptor()` throws if the span path runs — a live guard);
+  - `MethodCallProxyHandler.makeCall` headers: no MDC → no `traceparent`; MDC set → exactly the MDC
+    value (ADR-0003 byte parity), with logback supplying a real MDCAdapter.
+- **Red-first proof:** temporarily forcing `isNoop()` to return `false` turned **4 of the 7**
+  noSdkTest cases red (both identity fast-path checks + both `isNoop` checks); reverted.
+
+### B2 — production-chain container test
+
+- New `rpc-server/src/test/.../OtelProductionChainTest` (**2 tests, 0 failures**). Two real krpc
+  netty servers on loopback ports via the **production registration path**
+  (`RpcServerBuilder.Builder(APP).addService(...).build().startServer()` →
+  `.intercept(OtelServerInterceptor)`), driven by real krpc clients
+  (`new RpcClientFactory(APP, channel).get(iface)` → `MethodCallProxyHandler` →
+  `OtelClientInterceptor` + `PropagateTraceCall`). Order-service A's handler calls Ledger-service B
+  over the wire; in-process SDK exporter registered globally. This is the repo's existing
+  container-test pattern (mirrors `test-server`'s `GrpcContextAuthIT`/`GracefulShutdownIT`), not a
+  hand-built harness — it exercises the exact production wiring (only the Quarkus CDI wrapper
+  `RpcServiceExpose`, which just calls `RpcServerBuilder`, is not booted).
+  - `inboundToOrderToLedgerIsOneTraceWithCorrectParentage`: inbound root → CLIENT `/place` →
+    SERVER-A `/place` → CLIENT `/record` → SERVER-B `/record`, one trace id, full parent chain
+    (each `parentSpanId` asserted), and **exactly one `traceparent`** received on the A→B wire hop
+    (counted from `ServerContext.current().getHeaders()` inside service B).
+  - `exceptionPathEndsHopSpansWithErrorStatus`: service B throws; the SERVER-B and A→B CLIENT spans
+    for `/boom` end with `StatusCode.ERROR`.
+- The r1 `OtelPropagationHopTest` (raw in-process transport) is retained as a focused
+  interceptor-level check (rpc attributes + VT-scope), no longer standing in as the container test.
+
+### r2 verification summary
+
+- `rpc-common:test` 25 · `rpc-client:test` 23 · `rpc-server:test` 61 · `rpc-server:noSdkTest` 7 ·
+  `http-server:test` 17 = **133 tests, 0 failures**. `noSdkTest` is wired into `check`.
+- NS-3 grep unchanged (no SDK/exporter in any core runtime classpath). Native path unaffected by
+  the r2 changes (short-circuit is API-only, no new classes on the image path beyond `isNoop`).
+
+## Fixround r2 (codex: GlobalOpenTelemetry.get() pins-no-op landmine) — resolved
+
+### B1c — explicit injection, never `GlobalOpenTelemetry`
+
+- **Landmine removed.** Core no longer calls `GlobalOpenTelemetry` anywhere. r1's `isNoop()` read
+  `GlobalOpenTelemetry.get().getTracerProvider()`; on OTel API 1.49 `get()` on first read when unset
+  does a synchronized init that pins the JVM-global to a no-op (or reflectively autoconfigures an
+  SDK). A krpc call before the consumer's SDK registration would therefore permanently disable
+  tracing AND make the consumer's later `buildAndRegisterGlobal()` throw. **The r1 "per-call get"
+  design in the section above is superseded by this section.**
+- **New design.** `KrpcOtel` holds a `volatile OpenTelemetry otel = OpenTelemetry.noop()` with a
+  public `install(OpenTelemetry)` (idempotent-safe, null-ignored). `isNoop()` = `otel ==
+  OpenTelemetry.noop()` (one volatile read + reference compare, allocation-free). `tracer()` /
+  `propagator()` read the volatile. `grep GlobalOpenTelemetry` over all core `*/src/main/java` is
+  empty (only doc prose in ADR-0006 explains why it is avoided).
+- **Integration wiring (explicit install, no ambient magic):**
+  - Quarkus `RpcServiceExpose` (`@Startup`) injects `Instance<OpenTelemetry>`; `isResolvable()` →
+    `install(...)`, else stay no-op.
+  - Spring `RpcServiceExposer#onApplicationEvent` and `RpcClientAutoConfigure#afterPropertiesSet`
+    install via `getBeanProvider(...)`/`ObjectProvider.ifAvailable(...)`.
+  - Plain-netty: documented explicit `KrpcOtel.install(openTelemetry)` (ADR-0006 + javadoc).
+- **Empirical bean-availability caveat (honest):** the CDI `Instance<OpenTelemetry>` injection +
+  `install()` wiring compiles and is exercised by construction, but I did **not** boot a full
+  Quarkus app with `quarkus-opentelemetry` to observe `isResolvable()==true` at `@Startup`. The only
+  Quarkus module here (`test-server`) boots MySQL/agroal under `@QuarkusTest`, which is not runnable
+  in this environment (its ITs are deliberately plain, non-`@QuarkusTest`, for that reason). The
+  install path is correct by the CDI contract (`@Startup` runs after container init; `Instance` is
+  always injectable, `isResolvable()` reflects bean presence), and the production-chain test proves
+  the interceptors + `install()` trace end-to-end. Deployed Quarkus verification remains LH's iac
+  probe. NOT-verified is stated rather than faked.
+- **Ordering regression test** (`OtelInstallOrderingTest`, rpc-server, 1 test): a call intercepted
+  while no-op is unwrapped + emits no traceparent; after `install(sdk)` a call is wrapped, emits one
+  traceparent, and exports a CLIENT span; and `GlobalOpenTelemetry.set(...)` afterward does **not**
+  throw — proving core never pinned the global. Red-first: neutering `install()` turns it red.
+- **noSdkTest** assertions already design-agnostic (isNoop true on a genuinely SDK-free classpath +
+  unwrapped delegates) — still 7/7 green under the volatile design.
+
+### r2 verification summary
+
+- `rpc-common:test` 25 · `rpc-client:test` 23 · `rpc-server:test` 62 (+`OtelInstallOrderingTest`) ·
+  `rpc-server:noSdkTest` 7 · `http-server:test` 17 = **134 tests, 0 failures**.
+- `grep -rn GlobalOpenTelemetry rpc-*/src/main/java http-server/src/main/java` = **no matches**
+  (core main is global-free; tests use it only to assert it stays unpinned).
+- NS-3 unchanged (opentelemetry-api + opentelemetry-context only in core runtime). Native re-checked.
+
+## Fixround r3 (codex: Quarkus SDK-present branch IS locally provable) — resolved
+
+### B1d — positive-injection container proof in `examples:quickstart`
+
+r2's "unrunnable locally" claim was wrong: `examples:quickstart` is a DB-free Quarkus consumer with
+existing `@QuarkusTest` infra (no Agroal/JDBC). Added `OtelServerSpanQuarkusTest` there.
+
+- **Test-scope only** (published example's production deps unchanged): `testImplementation`
+  `quarkus-opentelemetry` + `opentelemetry-sdk-testing` + `rpc-client` + `grpc-stub`; a
+  `@Produces @Singleton InMemorySpanExporter` bean; a `src/test/resources/application.properties`
+  (merged with main) carrying the classloader config below. No `src/main` change to the example.
+- **Proves, in one @QuarkusTest:** (1) `Instance<OpenTelemetry>.isResolvable()==true` — the same
+  bean `RpcServiceExpose` injects at `@Startup`; (2) `KrpcOtel.isNoop()==false` — the startup hook
+  actually ran `install(...)`; (3) a real krpc gRPC call (`quickstart/Hello/hello`, over loopback
+  :50051) exports a SERVER span named `.../hello` with `rpc.system=grpc`, `rpc.method=hello`.
+- **Split-classloader fix:** a gRPC client referenced from a `@QuarkusTest` class hits a Quarkus
+  loader-constraint `LinkageError` (io.grpc / tech.krpc.internal / opentelemetry-api loaded by both
+  the base and Quarkus loaders). Resolved by (a) moving all `io.grpc` usage into a CDI bean
+  (`HelloGrpcCaller`, app loader) and (b) `quarkus.class-loading.parent-first-artifacts` for the
+  grpc-core (non-netty) + krpc + otel-api/context + protobuf/guava/perfmark artifacts, collapsing
+  them to one copy shared by both loaders (grpc-netty + io.netty stay app-loaded and see the
+  parent's grpc-api). This is **test-only config**, not a runtime/product concern.
+- **Red-first:** neutering the `RpcServiceExpose` install wiring (`if (false)`) turns the container
+  test red (isNoop stays true → no SERVER span); reverted.
+- The other three quickstart `@QuarkusTest`s (Agent/MCP, 3+5+1) still pass with OTel on the test
+  classpath.
+
+### r3 verification summary
+
+- `rpc-common:test` 25 · `rpc-client:test` 23 · `rpc-server:test` 62 · `rpc-server:noSdkTest` 7 ·
+  `http-server:test` 17 · `examples:quickstart:test` 10 (incl. the new container test) =
+  **144 tests, 0 failures**.
+- The Quarkus SDK-present injection branch is now proven locally. The only remaining deferral is
+  full OTLP export to a real backend (LH iac probe).

--- a/docs/roadmap/active-roadmap.md
+++ b/docs/roadmap/active-roadmap.md
@@ -87,8 +87,8 @@ Acceptance Criteria:
 
 ## AGENT-001: Agent-Friendly Introspection And MCP Surface
 
-Status: active  (P0 delivered on `dev`, security-reviewed; P1 MCP bridge implemented on
-`feat/mcp-bridge`, pending final review + merge)
+Status: active  (P0 + P1 both delivered on `dev` and security-reviewed; P1 MCP bridge merged to
+`dev` as PR #14, `9be92e6`. Remaining scope = uncommitted P2 ideas only.)
 
 Capability: Expose KRPC's runtime self-description to AI agents (discover → call)
 
@@ -116,7 +116,7 @@ Phases (sequenced P0 → P1):
     (JVM + native), no consumer action. Container-level `@QuarkusTest` added.
   - **Native: DONE.** `AgentInvokeRequest` reflection-config added; native build +
     boot verified (Mandrel 25/JDK25) with the agent endpoints reachable.
-- **P1 (IMPLEMENTED on `feat/mcp-bridge`, pending review + merge)** — MCP Streamable
+- **P1 (DELIVERED on `dev`, merged as PR #14 `9be92e6`)** — MCP Streamable
   HTTP bridge (`POST /mcp`, spec 2025-06-18, JSON-RPC 2.0), **not** a standalone
   module: a thin bridge on the P0 http-server host (ADR-0004 revised). `tools/list`
   generated from live `ApiMeta`; `tools/call` via the same `invokeWeb` path
@@ -139,3 +139,31 @@ Acceptance Criteria:
 - MCP module off by default adds no runtime surface.
 - No service registry/discovery/LB added (stays within ADR-0001).
 - Authentication remains gateway-side this phase.
+
+## OTEL-001: OpenTelemetry Span Creation On KRPC's Faces
+
+Status: active
+
+Capability: KRPC creates SERVER/CLIENT spans and extracts/injects W3C trace context on its own
+Netty faces (gRPC + HTTP), so a consumer with a provisioned OTLP pipeline gets connected traces
+across KRPC hops without application code. Span creation via the OpenTelemetry **API only** — no
+SDK/exporter in core (the SDK arrives from the consumer's Quarkus stack; ADR-0001 / NS-3).
+
+Components:
+
+- `rpc-common` (`KrpcOtel` — flag, tracer, gRPC metadata getter/setter, rpc/http attribute keys),
+  new `opentelemetry-api` dependency
+- `rpc-server` (`OtelServerInterceptor`, registered in `RpcServerBuilder`)
+- `rpc-client` (`OtelClientInterceptor`, installed in `MethodCallProxyHandler`)
+- `http-server` (`AbstractHttpHandler` SERVER-span extraction)
+- kill switch `rpc.otel.enabled` / env `KRPC_OTEL`, default ON (no-op without an SDK)
+
+ADR: ADR-0006 (amends ADR-0003's "no spans" clause)
+
+Acceptance Criteria:
+
+- Inbound `traceparent` → SERVER span → CLIENT span → outbound `traceparent`, one header, correct
+  parent chain across a real in-process hop (test-proven).
+- No behavior change without an OTel SDK (byte-identical wire; parity test).
+- No OTel SDK/exporter in any core module's runtime classpath (NS-3).
+- Native build + boot with the OTel surface, no reflection errors (NS-7).

--- a/examples/quickstart/build.gradle
+++ b/examples/quickstart/build.gradle
@@ -28,6 +28,17 @@ dependencies {
     testImplementation("io.quarkus:quarkus-junit5") {
         exclude module: 'quarkus-bootstrap-maven-resolver'
     }
+
+    // OTEL-001 B1d (ADR-0006): container proof that the consumer's OpenTelemetry CDI bean is
+    // resolvable at RpcServiceExpose @Startup and gets installed into krpc, so a real gRPC call
+    // exports a SERVER span. TEST SCOPE ONLY — the published example's production deps are unchanged
+    // (no OTel SDK/exporter ships with the example).
+    testImplementation("io.quarkus:quarkus-opentelemetry") {
+        exclude module: 'quarkus-bootstrap-maven-resolver'
+    }
+    testImplementation "io.opentelemetry:opentelemetry-sdk-testing:${otelVersion}"
+    testImplementation project(':rpc-client')
+    testImplementation "io.grpc:grpc-stub:${grpcVersion}"
 }
 
 // Convenience alias so `gradle :examples:quickstart:run` starts the server in

--- a/examples/quickstart/src/test/java/tech/krpc/examples/quickstart/HelloGrpcCaller.java
+++ b/examples/quickstart/src/test/java/tech/krpc/examples/quickstart/HelloGrpcCaller.java
@@ -1,0 +1,29 @@
+package tech.krpc.examples.quickstart;
+
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import jakarta.enterprise.context.ApplicationScoped;
+import tech.krpc.client.GeneralizeClient;
+
+/**
+ * OTEL-001 B1d (test scope only): makes a real krpc gRPC call to the quickstart server over the
+ * wire (loopback :50051). Lives in a CDI bean so all {@code io.grpc} usage runs in the Quarkus
+ * application classloader — the same loader as the server — avoiding the @QuarkusTest split-loader
+ * {@code LinkageError} that a gRPC client referenced directly from the test class triggers.
+ */
+@ApplicationScoped
+public class HelloGrpcCaller {
+
+    /** Calls {@code quickstart/Hello/hello} and returns the RpcResult code (0 = ok). */
+    public int callHello(String name) {
+        ManagedChannel channel = ManagedChannelBuilder.forAddress("127.0.0.1", 50051)
+                .usePlaintext().build();
+        try {
+            var out = GeneralizeClient.call(channel, "quickstart/Hello/hello",
+                    "{\"name\":\"" + name + "\"}");
+            return out.getC();
+        } finally {
+            channel.shutdownNow();
+        }
+    }
+}

--- a/examples/quickstart/src/test/java/tech/krpc/examples/quickstart/InMemorySpanExporterProducer.java
+++ b/examples/quickstart/src/test/java/tech/krpc/examples/quickstart/InMemorySpanExporterProducer.java
@@ -1,0 +1,21 @@
+package tech.krpc.examples.quickstart;
+
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
+
+/**
+ * OTEL-001 B1d (test scope only): Quarkus OpenTelemetry auto-wires a CDI {@link InMemorySpanExporter}
+ * bean as the span exporter, so a test can inject it and assert the spans krpc creates. This bean
+ * exists ONLY on the test classpath — the published quickstart ships no OTel SDK/exporter.
+ */
+@ApplicationScoped
+public class InMemorySpanExporterProducer {
+
+    @Produces
+    @Singleton
+    InMemorySpanExporter inMemorySpanExporter() {
+        return InMemorySpanExporter.create();
+    }
+}

--- a/examples/quickstart/src/test/java/tech/krpc/examples/quickstart/OtelServerSpanQuarkusTest.java
+++ b/examples/quickstart/src/test/java/tech/krpc/examples/quickstart/OtelServerSpanQuarkusTest.java
@@ -1,0 +1,93 @@
+package tech.krpc.examples.quickstart;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.TimeUnit;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import tech.krpc.context.KrpcOtel;
+
+/**
+ * OTEL-001 B1d (ADR-0006): positive-injection container proof. Boots the quickstart — a DB-free
+ * Quarkus consumer — WITH {@code quarkus-opentelemetry} on the test classpath (production deps
+ * unchanged). Proves the explicit-injection path end to end:
+ *
+ * <ol>
+ *   <li>the container's {@link OpenTelemetry} CDI bean is resolvable (the same bean
+ *       {@code RpcServiceExpose}'s {@code Instance<OpenTelemetry>} sees at {@code @Startup});
+ *   <li>{@code RpcServiceExpose} therefore ran {@link KrpcOtel#install} — {@link KrpcOtel#isNoop()}
+ *       is false;
+ *   <li>a real krpc gRPC call through the quickstart {@code Hello} service exports a SERVER span
+ *       with the rpc semantic attributes.
+ * </ol>
+ *
+ * <p>The gRPC call is made from {@link HelloGrpcCaller} (a CDI bean) so all {@code io.grpc} usage
+ * runs in the Quarkus application classloader; the test class itself references no {@code io.grpc}
+ * type, avoiding the @QuarkusTest split-classloader {@code LinkageError}.
+ *
+ * <p>Red-first: with the install wiring neutered (or the bean absent) step 2 flips true, the server
+ * interceptor short-circuits, and the span assertion in step 3 goes red.
+ */
+@QuarkusTest
+class OtelServerSpanQuarkusTest {
+
+    @Inject
+    InMemorySpanExporter spanExporter;
+
+    @Inject
+    Instance<OpenTelemetry> openTelemetry;
+
+    @Inject
+    HelloGrpcCaller grpcCaller;
+
+    @BeforeEach
+    void reset() {
+        spanExporter.reset();
+    }
+
+    @Test
+    void containerOpenTelemetryIsInstalled_andGrpcCallExportsServerSpan() throws Exception {
+        // 1) The container's OpenTelemetry bean is resolvable (same bean RpcServiceExpose injects).
+        assertTrue(openTelemetry.isResolvable(),
+                "quarkus-opentelemetry must expose a resolvable OpenTelemetry CDI bean");
+
+        // 2) RpcServiceExpose@Startup installed it into krpc — no global probing, explicit inject.
+        assertFalse(KrpcOtel.isNoop(),
+                "RpcServiceExpose must have installed the container OpenTelemetry into krpc at startup");
+
+        // 3) A real krpc gRPC call to the quickstart Hello service (over the wire, port 50051).
+        int code = grpcCaller.callHello("otel-quarkus");
+        assertEquals(0, code, "the gRPC call must succeed (RpcResult code 0)");
+
+        SpanData server = awaitServerSpan();
+        assertTrue(server.getName().endsWith("/hello"),
+                "SERVER span name must be the full gRPC method, got " + server.getName());
+        assertEquals("grpc", server.getAttributes().get(KrpcOtel.RPC_SYSTEM));
+        assertEquals("hello", server.getAttributes().get(KrpcOtel.RPC_METHOD));
+    }
+
+    private SpanData awaitServerSpan() throws InterruptedException {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+        while (System.nanoTime() < deadline) {
+            for (SpanData s : spanExporter.getFinishedSpanItems()) {
+                if (s.getKind() == SpanKind.SERVER && s.getName().endsWith("/hello")) {
+                    return s;
+                }
+            }
+            Thread.sleep(50);
+        }
+        throw new AssertionError("no SERVER span for the Hello call was exported; spans="
+                + spanExporter.getFinishedSpanItems());
+    }
+}

--- a/examples/quickstart/src/test/resources/application.properties
+++ b/examples/quickstart/src/test/resources/application.properties
@@ -1,0 +1,11 @@
+# OTEL-001 B1d (TEST SCOPE ONLY — does not ship with the published example).
+# Keep the example's runtime config (merged with src/main/resources/application.properties).
+rpc.server.app = quickstart
+rpc.server.port = 50051
+
+# @QuarkusTest split-classloader fix: the test drives a real gRPC client (rpc-client) against the
+# in-JVM krpc server. Without this, io.grpc is loaded by BOTH the base loader (test deps) and the
+# QuarkusClassLoader (app runtime) -> LinkageError (loader constraint) on io.grpc.MethodDescriptor.
+# Making the grpc CORE (non-netty) + its transitives parent-first collapses them to one copy shared
+# by both loaders; grpc-netty + io.netty stay app-loaded (child) and see the parent's grpc-api.
+quarkus.class-loading.parent-first-artifacts=io.grpc:grpc-api,io.grpc:grpc-core,io.grpc:grpc-stub,io.grpc:grpc-util,io.grpc:grpc-context,io.grpc:grpc-protobuf-lite,io.perfmark:perfmark-api,com.google.guava:guava,com.google.protobuf:protobuf-javalite,tech.krpc:rpc-api,tech.krpc:rpc-common,tech.krpc:rpc-client,io.opentelemetry:opentelemetry-api,io.opentelemetry:opentelemetry-context

--- a/gradle.properties
+++ b/gradle.properties
@@ -49,6 +49,12 @@ errorProneVersion=2.45.0
 ## above override grpc-api dependency//
 # common lib
 lombokVersion=1.18.42
+# OTEL-001 (ADR-0006): OpenTelemetry API only — span creation joins the framework via the
+# OTel *API/instrumentation*, never the SDK/exporter (ADR-0001 / NS-3). Pinned to the OTel
+# SDK version shipped by the Quarkus 3.33 LTS BOM (1.49.0) so krpc's compile-time API matches
+# the consumer's runtime API exactly — zero skew. Consumers' Quarkus BOM still wins the
+# transitive version (this is a plain api dep, not a published platform constraint).
+otelVersion=1.49.0
 slf4jVersion=2.0.17
 #slf4jVersion=1.7.36
 jacksonVersion=2.19.4

--- a/http-server/build.gradle
+++ b/http-server/build.gradle
@@ -21,6 +21,8 @@ dependencies {
     // HARDEN-B4 Part A: in-process netty pipeline tests (EmbeddedChannel + real bind).
     testImplementation "org.junit.jupiter:junit-jupiter:5.11.4"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher"
+    // OTEL-001: OTel SDK test exporter (test scope only — no SDK in core runtime, NS-3).
+    testImplementation "io.opentelemetry:opentelemetry-sdk-testing:${otelVersion}"
 
 }
 

--- a/http-server/src/main/java/tech/krpc/http/server/AbstractHttpHandler.java
+++ b/http-server/src/main/java/tech/krpc/http/server/AbstractHttpHandler.java
@@ -41,6 +41,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import tech.krpc.util.JsonUtils;
 import tech.krpc.util.JsonDecodeException;
+import tech.krpc.context.KrpcOtel;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.context.propagation.TextMapGetter;
 
 /**
  *
@@ -72,6 +79,22 @@ public abstract class AbstractHttpHandler extends SimpleChannelInboundHandler<Fu
     // back onto the channel's eventLoop (netty threading model: writes belong to the eventLoop,
     // never a foreign thread). Virtual threads are daemon, so no explicit shutdown is needed.
     static final ExecutorService HANDLER_VT = Executors.newVirtualThreadPerTaskExecutor();
+
+    // OTEL-001 (ADR-0006): resolved once (KrpcOtel.enabled() is a constant) so the disabled path
+    // JIT-folds to the original behaviour — zero cost, zero wire change.
+    private static final boolean OTEL_ENABLED = KrpcOtel.enabled();
+
+    // W3C context extraction from inbound Netty HTTP headers (webhook/callback entry).
+    private static final TextMapGetter<HttpHeaders> HTTP_HEADERS_GETTER = new TextMapGetter<>() {
+        @Override
+        public Iterable<String> keys(HttpHeaders carrier) {
+            return carrier == null ? java.util.List.of() : carrier.names();
+        }
+        @Override
+        public String get(HttpHeaders carrier, String key) {
+            return carrier == null ? null : carrier.get(key);
+        }
+    };
 
     // O6 (HARDEN-B4 fix round 1): per-connection response-ordering state. The handler is @Sharable,
     // so per-channel state lives in a channel attribute, not an instance field. See ConnState.
@@ -155,10 +178,23 @@ public abstract class AbstractHttpHandler extends SimpleChannelInboundHandler<Fu
             String contentType;
             byte[] bytes;
             List<AsciiHeader> extHeaders = new ArrayList<AsciiHeader>();
+            // OTEL-001 (ADR-0006): SERVER span for the handled request, W3C context extracted from
+            // the request headers. null when disabled / no-op without an OTel SDK — behaviour and
+            // wire stay identical. makeCurrent() puts the span in scope so any outbound client call
+            // the handler makes on this virtual thread parents to it.
+            // B1 (ADR-0006): skip span creation when disabled OR when no OTel SDK is present
+            // (no-op TracerProvider) — no extract, no span, no scope. Per-call check (isNoop) so a
+            // late-registered SDK still traces; allocation-free on the no-SDK fast path.
+            Span span = (OTEL_ENABLED && !KrpcOtel.isNoop())
+                    ? startHttpServerSpan(handler, requestHeaders) : null;
+            Scope scope = span != null ? span.makeCurrent() : null;
             try {
                 bytes = handler.handle(dto, extHeaders, requestHeaders);
                 status = extractStatusOverride(extHeaders);
                 contentType = handler.contextType();
+                if (span != null) {
+                    span.setAttribute(KrpcOtel.HTTP_RESPONSE_STATUS_CODE, (long) status.code());
+                }
             } catch (final Throwable ex) {
                 // C7 + AUD-omp-21: never echo ex.getMessage() — internal reason stays in the log;
                 // client gets a neutral 500 JSON envelope. Catch Throwable so the response AND the
@@ -168,6 +204,18 @@ public abstract class AbstractHttpHandler extends SimpleChannelInboundHandler<Fu
                 contentType = TYPE_JSON;
                 bytes = errorBody(status, null);
                 extHeaders = null;
+                if (span != null) {
+                    span.setAttribute(KrpcOtel.HTTP_RESPONSE_STATUS_CODE, (long) status.code());
+                    span.setStatus(StatusCode.ERROR);
+                    span.recordException(ex);
+                }
+            } finally {
+                if (scope != null) {
+                    scope.close();
+                }
+                if (span != null) {
+                    span.end();
+                }
             }
             final HttpResponseStatus fStatus = status;
             final String fContentType = contentType;
@@ -181,6 +229,17 @@ public abstract class AbstractHttpHandler extends SimpleChannelInboundHandler<Fu
                 }
             });
         });
+    }
+
+    // OTEL-001 (ADR-0006): extract inbound W3C context from the HTTP headers and start a SERVER
+    // span named after the handler path. No-op tracer/propagator without an OTel SDK.
+    private static Span startHttpServerSpan(Handler<?> handler, HttpHeaders requestHeaders) {
+        Context parent = KrpcOtel.propagator()
+                .extract(Context.current(), requestHeaders, HTTP_HEADERS_GETTER);
+        return KrpcOtel.tracer().spanBuilder(handler.path())
+                .setSpanKind(SpanKind.SERVER)
+                .setParent(parent)
+                .startSpan();
     }
 
     /**

--- a/http-server/src/test/java/tech/krpc/http/server/HttpOtelSpanTest.java
+++ b/http-server/src/test/java/tech/krpc/http/server/HttpOtelSpanTest.java
@@ -1,0 +1,200 @@
+package tech.krpc.http.server;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.ServerSocket;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.netty.handler.codec.http.HttpHeaders;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
+import io.opentelemetry.context.propagation.ContextPropagators;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import tech.krpc.context.KrpcOtel;
+
+/**
+ * OTEL-001 (ADR-0006): the HTTP handler's SERVER span. Boots a real in-process {@link HttpServer}
+ * and drives it with {@link HttpClient}, asserting that:
+ *
+ * <ul>
+ *   <li>an inbound W3C {@code traceparent} is extracted and the handler's SERVER span becomes its
+ *       child (same trace id, parent = the inbound span id);
+ *   <li>the span is current on the handler thread (a virtual thread);
+ *   <li>a request with no inbound context still gets a fresh root SERVER span.
+ * </ul>
+ */
+class HttpOtelSpanTest {
+
+    private int port;
+    private TraceHandler handler;
+    private HttpServer server;
+    private HttpClient client;
+    private InMemorySpanExporter exporter;
+    private SdkTracerProvider tracerProvider;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        KrpcOtel.install(OpenTelemetry.noop());
+        exporter = InMemorySpanExporter.create();
+        tracerProvider = SdkTracerProvider.builder()
+                .addSpanProcessor(SimpleSpanProcessor.create(exporter))
+                .build();
+        KrpcOtel.install(OpenTelemetrySdk.builder()
+                .setTracerProvider(tracerProvider)
+                .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.getInstance()))
+                .build());
+
+        try (ServerSocket ss = new ServerSocket(0)) {
+            port = ss.getLocalPort();
+        }
+        handler = new TraceHandler();
+        server = new HttpServer(handler, port);
+        server.start();
+        client = HttpClient.newBuilder()
+                .version(HttpClient.Version.HTTP_1_1)
+                .connectTimeout(Duration.ofSeconds(5))
+                .build();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (client != null) {
+            client.close();
+        }
+        if (server != null) {
+            server.shutdown();
+        }
+        if (tracerProvider != null) {
+            tracerProvider.shutdown();
+        }
+        KrpcOtel.install(OpenTelemetry.noop());
+    }
+
+    @Test
+    void inboundTraceparent_becomesServerSpanParent() throws Exception {
+        String traceId = "0af7651916cd43dd8448eb211c80319c";
+        String parentSpanId = "b7ad6b7169203331";
+        String traceparent = "00-" + traceId + "-" + parentSpanId + "-01";
+
+        HttpResponse<String> r = client.send(
+                HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + port + "/trace"))
+                        .header("Content-Type", "application/json")
+                        .header("traceparent", traceparent)
+                        .POST(HttpRequest.BodyPublishers.ofString("{}"))
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+        assertEquals(200, r.statusCode());
+
+        SpanData span = awaitServerSpan();
+        assertEquals(traceId, span.getTraceId(), "SERVER span must join the inbound trace");
+        assertEquals(parentSpanId, span.getParentSpanId(),
+                "SERVER span must be a child of the inbound traceparent span");
+        assertEquals("/trace", span.getName(), "span name is the handler path");
+        assertEquals(SpanKind.SERVER, span.getKind());
+        assertEquals(200L, span.getAttributes().get(KrpcOtel.HTTP_RESPONSE_STATUS_CODE));
+
+        // Scope propagated to the handler's virtual thread.
+        assertTrue(handler.threadVirtual.get(), "handler must run on a virtual thread");
+        assertNotNull(handler.observed.get());
+        assertTrue(handler.observed.get().isValid(), "the SERVER span must be current in the handler");
+        assertEquals(span.getSpanId(), handler.observed.get().getSpanId());
+    }
+
+    @Test
+    void noInboundContext_createsRootServerSpan() throws Exception {
+        HttpResponse<String> r = client.send(
+                HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + port + "/trace"))
+                        .header("Content-Type", "application/json")
+                        .POST(HttpRequest.BodyPublishers.ofString("{}"))
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+        assertEquals(200, r.statusCode());
+
+        SpanData span = awaitServerSpan();
+        assertTrue(span.getSpanContext().isValid(), "a fresh root SERVER span must be created");
+        assertFalse(span.getParentSpanContext().isValid(),
+                "with no inbound context the SERVER span is a trace root");
+    }
+
+    private SpanData awaitServerSpan() throws InterruptedException {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+        while (System.nanoTime() < deadline) {
+            List<SpanData> spans = exporter.getFinishedSpanItems();
+            if (!spans.isEmpty()) {
+                return spans.get(0);
+            }
+            Thread.sleep(20);
+        }
+        throw new AssertionError("no SERVER span was exported");
+    }
+
+    /** A handler that records the current span + thread kind during handle(). */
+    static final class TraceHandler extends AbstractHttpHandler {
+        final AtomicReference<SpanContext> observed = new AtomicReference<>();
+        final AtomicBoolean threadVirtual = new AtomicBoolean(false);
+
+        TraceHandler() {
+            postMap.put("/trace", new PostHandler<String>() {
+                @Override
+                public Class<String> getParamClass() {
+                    return String.class;
+                }
+
+                @Override
+                public String path() {
+                    return "/trace";
+                }
+
+                @Override
+                public boolean useValidator() {
+                    return false;
+                }
+
+                @Override
+                public byte[] handle(String param, List<AsciiHeader> resHeader, HttpHeaders requestHeaders) {
+                    threadVirtual.set(Thread.currentThread().isVirtual());
+                    observed.set(Span.current().getSpanContext());
+                    return "{\"ok\":true}".getBytes(StandardCharsets.UTF_8);
+                }
+
+                @Override
+                public String contextType() {
+                    return AbstractHttpHandler.TYPE_JSON;
+                }
+            });
+        }
+
+        @Override
+        public Validator getValidator() {
+            return null;
+        }
+
+        @Override
+        public void initHandler() {
+        }
+    }
+}

--- a/rpc-client-spring/src/main/java/tech/krpc/client/spring/RpcClientAutoConfigure.java
+++ b/rpc-client-spring/src/main/java/tech/krpc/client/spring/RpcClientAutoConfigure.java
@@ -53,6 +53,11 @@ public class RpcClientAutoConfigure implements InitializingBean {
     @Autowired
     Environment environment;
 
+    // OTEL-001 (ADR-0006): the Spring context's OpenTelemetry, if present (micrometer-tracing /
+    // OTel starter). ObjectProvider so a client-only app without an OTel starter stays no-op.
+    @Autowired(required = false)
+    org.springframework.beans.factory.ObjectProvider<io.opentelemetry.api.OpenTelemetry> otelProvider;
+
     @Override
     public void afterPropertiesSet() throws Exception {
         log.debug("*******************rpc.enable RpcClientAutoConfigure*******************************");
@@ -64,6 +69,13 @@ public class RpcClientAutoConfigure implements InitializingBean {
         ClientDeadline.setDefaultDeadlineMillis(millis);
         log.info("[ RPC Client ] default deadline = {} ms ({})", millis,
                 millis <= 0 ? "unlimited" : "hung upstream will be cut");
+        // OTEL-001: explicitly install the Spring OpenTelemetry into krpc (no global probing).
+        if (otelProvider != null) {
+            otelProvider.ifAvailable(otel -> {
+                tech.krpc.context.KrpcOtel.install(otel);
+                log.info("OTel: installed Spring OpenTelemetry into krpc client (tracing active).");
+            });
+        }
     }
 
 

--- a/rpc-client/build.gradle
+++ b/rpc-client/build.gradle
@@ -24,6 +24,12 @@ dependencies {
     testImplementation "org.junit.jupiter:junit-jupiter:5.11.4"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher"
     testImplementation "io.grpc:grpc-stub:${grpcVersion}"
+    // OTEL-001: OTel SDK test exporter (test scope only — no SDK in core runtime, NS-3).
+    testImplementation "io.opentelemetry:opentelemetry-sdk-testing:${otelVersion}"
+    // OTEL-001: logback-classic provides a real MDCAdapter (LogbackMDCAdapter) so the ADR-0003 MDC
+    // traceparent path is exercisable in the coexistence/parity test. slf4j-simple and the no-binding
+    // fallback both ship a NOPMDCAdapter (MDC inert), which would silently skip the MDC assertion.
+    testRuntimeOnly "ch.qos.logback:logback-classic:1.5.18"
 }
 
 test {

--- a/rpc-client/src/main/java/tech/krpc/client/MethodCallProxyHandler.java
+++ b/rpc-client/src/main/java/tech/krpc/client/MethodCallProxyHandler.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import tech.krpc.annotation.Cached;
 import tech.krpc.common.FilterChain;
 import tech.krpc.common.MethodStub;
+import tech.krpc.context.KrpcOtel;
 import tech.krpc.context.TraceMeta;
 import tech.krpc.filter.FilterInvokeHelper;
 import tech.krpc.internal.InputProto;
@@ -34,7 +35,11 @@ import org.slf4j.MDC;
 @Slf4j
 public class MethodCallProxyHandler<T> implements InvocationHandler {
 
-    private final ManagedChannel channel;
+    // OTEL-001 (ADR-0006): the RPC channel, wrapped with the OTel CLIENT interceptor when enabled.
+    // Widened to io.grpc.Channel (ClientInterceptors.intercept returns a Channel, not a
+    // ManagedChannel); only newCall() is used here, and channel lifecycle stays with the caller's
+    // ManagedChannel (RpcClientFactory.close()).
+    private final io.grpc.Channel channel;
     final Class<T>       clz;
 
     final Map<Method, ChannelMethodInvoker> stubMap = new HashMap<>();
@@ -53,7 +58,12 @@ public class MethodCallProxyHandler<T> implements InvocationHandler {
                                   CacheManager cacheManager,
                                   SerialEnum serialEnum) {
         this.serverName = serverName;
-        this.channel = channel;
+        // OTEL-001 (ADR-0006): install the CLIENT interceptor (CLIENT span + W3C traceparent
+        // injection). Default ON; no-op without an OTel SDK. When off, the raw channel is used —
+        // ADR-0003 MDC forwarding is untouched.
+        this.channel = KrpcOtel.enabled()
+                ? io.grpc.ClientInterceptors.intercept(channel, new OtelClientInterceptor())
+                : channel;
         this.clz = clz;
 
         this.filterChain = new FilterInvokeHelper<>

--- a/rpc-client/src/main/java/tech/krpc/client/OtelClientInterceptor.java
+++ b/rpc-client/src/main/java/tech/krpc/client/OtelClientInterceptor.java
@@ -1,0 +1,102 @@
+package tech.krpc.client;
+
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ForwardingClientCall;
+import io.grpc.ForwardingClientCallListener;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.Status;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+
+import tech.krpc.context.KrpcOtel;
+
+/**
+ * ADR-0006: gRPC CLIENT interceptor. Starts a CLIENT span (child of the current context — the
+ * SERVER span when the call originates inside a handler) and injects W3C {@code traceparent} into
+ * the outbound metadata, so the downstream server continues the same trace.
+ *
+ * <p>Uses the OpenTelemetry API only (no SDK — ADR-0001 / NS-3). Until an SDK is installed
+ * ({@link KrpcOtel#install}), {@code isNoop()} is true and this interceptor is a pass-through: no
+ * span, no injection, and the ADR-0003 MDC-forwarded {@code traceparent} survives unchanged — one
+ * header, byte-identical wire (NS-4). With an SDK installed, {@link KrpcOtel#METADATA_SETTER}
+ * overwrites, so the client-span {@code traceparent} supersedes the MDC-forwarded parent.
+ */
+public final class OtelClientInterceptor implements ClientInterceptor {
+
+    @Override
+    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+            MethodDescriptor<ReqT, RespT> method, CallOptions callOptions, Channel next) {
+        // B1 (ADR-0006): no OTel SDK -> no-op TracerProvider. Return the raw call unwrapped (no
+        // span, no injection); ADR-0003 MDC forwarding still applies. Zero allocation beyond the check.
+        if (KrpcOtel.isNoop()) {
+            return next.newCall(method, callOptions);
+        }
+        return new TracingClientCall<>(next.newCall(method, callOptions), method);
+    }
+
+    private static final class TracingClientCall<ReqT, RespT>
+            extends ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT> {
+
+        private final MethodDescriptor<ReqT, RespT> method;
+        private Span span;
+
+        TracingClientCall(ClientCall<ReqT, RespT> delegate, MethodDescriptor<ReqT, RespT> method) {
+            super(delegate);
+            this.method = method;
+        }
+
+        @Override
+        public void start(Listener<RespT> responseListener, Metadata headers) {
+            span = KrpcOtel.tracer().spanBuilder(method.getFullMethodName())
+                    .setSpanKind(SpanKind.CLIENT)
+                    .setAttribute(KrpcOtel.RPC_SYSTEM, KrpcOtel.RPC_SYSTEM_GRPC)
+                    .setAttribute(KrpcOtel.RPC_SERVICE, nullToEmpty(method.getServiceName()))
+                    .setAttribute(KrpcOtel.RPC_METHOD, nullToEmpty(method.getBareMethodName()))
+                    .startSpan();
+            // Parent is Context.current() (the default): the SERVER span in scope on the handler
+            // thread when the call originates inside a handler; Context.root() otherwise.
+            Context ctx = Context.current().with(span);
+            try (Scope scope = ctx.makeCurrent()) {
+                // Inject with the client-span context so the emitted traceparent reflects this span.
+                KrpcOtel.propagator()
+                        .inject(ctx, headers, KrpcOtel.METADATA_SETTER);
+                super.start(new TracingClientCallListener<>(responseListener, span), headers);
+            }
+        }
+
+        private static String nullToEmpty(String s) {
+            return s == null ? "" : s;
+        }
+    }
+
+    private static final class TracingClientCallListener<RespT>
+            extends ForwardingClientCallListener.SimpleForwardingClientCallListener<RespT> {
+
+        private final Span span;
+
+        TracingClientCallListener(ClientCall.Listener<RespT> delegate, Span span) {
+            super(delegate);
+            this.span = span;
+        }
+
+        @Override
+        public void onClose(Status status, Metadata trailers) {
+            span.setAttribute(KrpcOtel.RPC_GRPC_STATUS_CODE, (long) status.getCode().value());
+            if (!status.isOk()) {
+                span.setStatus(StatusCode.ERROR, status.getCode().name());
+                if (status.getCause() != null) {
+                    span.recordException(status.getCause());
+                }
+            }
+            span.end();
+            super.onClose(status, trailers);
+        }
+    }
+}

--- a/rpc-client/src/test/java/tech/krpc/client/OtelClientMdcParityTest.java
+++ b/rpc-client/src/test/java/tech/krpc/client/OtelClientMdcParityTest.java
@@ -1,0 +1,208 @@
+package tech.krpc.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
+
+import io.grpc.CallOptions;
+import io.grpc.ClientCall;
+import io.grpc.ManagedChannel;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.context.propagation.ContextPropagators;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+
+import tech.krpc.context.KrpcOtel;
+import tech.krpc.context.TraceMeta;
+import tech.krpc.internal.InputProto;
+import tech.krpc.internal.OutputProto;
+import tech.krpc.internal.SerialEnum;
+
+/**
+ * OTEL-001 (ADR-0006): the client-side coexistence contract between the OTel CLIENT interceptor
+ * (span + W3C injection) and ADR-0003's MDC {@code traceparent} forwarding. Both live in the
+ * outbound call chain built by {@link MethodCallProxyHandler#makeCall} (PropagateTraceCall wraps
+ * the OTel-intercepted call). The invariant defended here is <b>exactly one {@code traceparent} on
+ * the wire in every mode</b>:
+ *
+ * <ul>
+ *   <li>no OTel SDK + inbound MDC traceparent → the MDC value is forwarded, one header
+ *       (byte-identical to pre-OTEL ADR-0003 — the no-SDK parity proof);
+ *   <li>no OTel SDK + no MDC → no traceparent at all (baseline unchanged);
+ *   <li>OTel SDK present → the CLIENT-span traceparent supersedes any stale MDC value, still one
+ *       header, and it is a child of the current (server) span.
+ * </ul>
+ */
+class OtelClientMdcParityTest {
+
+    /** Records the metadata + listener handed to {@code start()} for outbound inspection. */
+    private static final class RecordingClientCall<Req, Resp> extends ClientCall<Req, Resp> {
+        volatile Metadata captured;
+        volatile Listener<Resp> listener;
+
+        @Override
+        public void start(Listener<Resp> responseListener, Metadata headers) {
+            this.listener = responseListener;
+            this.captured = headers;
+        }
+
+        @Override public void request(int numMessages) {}
+        @Override public void cancel(String message, Throwable cause) {}
+        @Override public void halfClose() {}
+        @Override public void sendMessage(Req message) {}
+    }
+
+    private static final class RecordingChannel extends ManagedChannel {
+        final RecordingClientCall<InputProto, OutputProto> call = new RecordingClientCall<>();
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <R, P> ClientCall<R, P> newCall(MethodDescriptor<R, P> md, CallOptions opts) {
+            return (ClientCall<R, P>) call;
+        }
+
+        @Override public String authority() { return "test-authority"; }
+        @Override public ManagedChannel shutdown() { return this; }
+        @Override public ManagedChannel shutdownNow() { return this; }
+        @Override public boolean isShutdown() { return false; }
+        @Override public boolean isTerminated() { return false; }
+        @Override public boolean awaitTermination(long timeout, TimeUnit unit) { return true; }
+    }
+
+    private RecordingChannel channel;
+    private MethodCallProxyHandler<CacheTestRpc>.ChannelMethodInvoker invoker;
+    private InMemorySpanExporter exporter;
+    private SdkTracerProvider tracerProvider;
+    private OpenTelemetrySdk sdk;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        KrpcOtel.install(OpenTelemetry.noop());
+        MDC.clear();
+        channel = new RecordingChannel();
+        var handler = new MethodCallProxyHandler<>(
+                "otel-parity", channel, CacheTestRpc.class, List.of(), null, SerialEnum.JSON);
+        Method bytesMethod = CacheTestRpc.class.getMethod("bytesMethod", byte[].class);
+        invoker = handler.stubMap.get(bytesMethod);
+        assertNotNull(invoker, "bytesMethod must have a wired invoker");
+    }
+
+    @AfterEach
+    void tearDown() {
+        MDC.clear();
+        if (tracerProvider != null) {
+            tracerProvider.shutdown();
+            tracerProvider = null;
+        }
+        KrpcOtel.install(OpenTelemetry.noop());
+    }
+
+    private void registerSdk() {
+        exporter = InMemorySpanExporter.create();
+        tracerProvider = SdkTracerProvider.builder()
+                .addSpanProcessor(SimpleSpanProcessor.create(exporter))
+                .build();
+        sdk = OpenTelemetrySdk.builder()
+                .setTracerProvider(tracerProvider)
+                .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.getInstance()))
+                .build();
+        KrpcOtel.install(sdk);
+    }
+
+    private List<String> outboundTraceparents() {
+        Iterable<String> all = channel.call.captured.getAll(TraceMeta.TRACEPARENT_KEY);
+        assertNotNull(channel.call.captured, "the call must have been started");
+        var list = new java.util.ArrayList<String>();
+        if (all != null) {
+            all.forEach(list::add);
+        }
+        return list;
+    }
+
+    @Test
+    void noSdk_mdcTraceparent_forwardedAsSingleHeader() {
+        // ADR-0003 parity: no OTel SDK, an inbound traceparent in MDC → forwarded unchanged, once.
+        String parent = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01";
+        MDC.put(TraceMeta.MDC_TRACEPARENT, parent);
+
+        invoker.makeCall(CallOptions.DEFAULT).start(new NoopListener(), new Metadata());
+
+        assertEquals(List.of(parent), outboundTraceparents(),
+                "no-SDK mode must forward exactly the MDC traceparent (ADR-0003 byte parity)");
+    }
+
+    @Test
+    void noSdk_noMdc_noTraceparent() {
+        // Baseline: nothing to forward, no SDK → no traceparent header emitted.
+        invoker.makeCall(CallOptions.DEFAULT).start(new NoopListener(), new Metadata());
+        assertTrue(outboundTraceparents().isEmpty(),
+                "with no SDK and no MDC context, no traceparent may be emitted");
+    }
+
+    @Test
+    void sdkPresent_clientSpanTraceparent_supersedesStaleMdc_singleHeader() {
+        registerSdk();
+        // A stale MDC parent from a *different* trace — it must NOT leak onto the wire.
+        String staleTraceId = "0af7651916cd43dd8448eb211c80319c";
+        MDC.put(TraceMeta.MDC_TRACEPARENT, "00-" + staleTraceId + "-b7ad6b7169203331-01");
+
+        Span server = sdk.getTracer("test")
+                .spanBuilder("inbound").startSpan();
+        try (Scope scope = server.makeCurrent()) {
+            invoker.makeCall(CallOptions.DEFAULT).start(new NoopListener(), new Metadata());
+            // End the CLIENT span (RecordingClientCall never fires the listener itself) so it exports.
+            channel.call.listener.onClose(io.grpc.Status.OK, new Metadata());
+        } finally {
+            server.end();
+        }
+
+        List<String> traceparents = outboundTraceparents();
+        assertEquals(1, traceparents.size(),
+                "SDK mode must emit exactly one traceparent (no MDC + OTel duplication)");
+
+        String[] parts = traceparents.get(0).split("-");
+        String outTraceId = parts[1];
+        String outSpanId = parts[2];
+
+        // The emitted traceparent belongs to the server's trace, not the stale MDC trace.
+        assertEquals(server.getSpanContext().getTraceId(), outTraceId,
+                "outbound traceparent must carry the current (server) trace id");
+        assertNotEquals(staleTraceId, outTraceId,
+                "the stale MDC traceparent must be superseded, not forwarded");
+
+        // The emitted span id is the CLIENT span, a child of the server span.
+        SpanData client = clientSpan();
+        assertEquals(outSpanId, client.getSpanId(),
+                "outbound traceparent span id must be the CLIENT span");
+        assertEquals(server.getSpanContext().getSpanId(), client.getParentSpanId(),
+                "CLIENT span must be a child of the current server span");
+    }
+
+    private SpanData clientSpan() {
+        return exporter.getFinishedSpanItems().stream()
+                .filter(s -> s.getKind() == io.opentelemetry.api.trace.SpanKind.CLIENT)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("no CLIENT span was exported"));
+    }
+
+    private static final class NoopListener extends ClientCall.Listener<OutputProto> {
+    }
+}

--- a/rpc-common/build.gradle
+++ b/rpc-common/build.gradle
@@ -21,6 +21,12 @@ dependencies {
 //    api 'jakarta.json.bind:jakarta.json.bind-api:2.0.0'
     api "org.slf4j:slf4j-api:$slf4jVersion"
 
+    // OTEL-001 (ADR-0006): OpenTelemetry API only (no SDK/exporter — ADR-0001 / NS-3). Exposed
+    // as `api` so the gRPC server/client interceptors (rpc-server / rpc-client) and the HTTP
+    // handler (http-server) inherit it. With no OTel SDK on the consumer classpath,
+    // GlobalOpenTelemetry is a no-op: zero spans, zero header changes, zero cost beyond a no-op call.
+    api "io.opentelemetry:opentelemetry-api:${otelVersion}"
+
 //    implementation 'org.yaml:snakeyaml:1.28'
 //    implementation 'org.apache.commons:commons-lang3:3.12.0'
     implementation "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"

--- a/rpc-common/src/main/java/tech/krpc/context/KrpcOtel.java
+++ b/rpc-common/src/main/java/tech/krpc/context/KrpcOtel.java
@@ -1,0 +1,153 @@
+package tech.krpc.context;
+
+import io.grpc.Metadata;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.propagation.TextMapPropagator;
+import io.opentelemetry.context.propagation.TextMapGetter;
+import io.opentelemetry.context.propagation.TextMapSetter;
+
+/**
+ * ADR-0006: span creation joins the framework via the OpenTelemetry <em>API</em> only. No OTel
+ * SDK/exporter enters core (ADR-0001 / NS-3); the SDK arrives from the consumer's stack.
+ *
+ * <p><b>Explicit injection, never the JVM-global accessor.</b> Core holds a {@code volatile}
+ * {@link OpenTelemetry} reference, {@link OpenTelemetry#noop()} until an integration explicitly
+ * calls {@link #install(OpenTelemetry)} (the Quarkus/Spring startup hooks wire the container's
+ * {@code OpenTelemetry} bean; plain-netty users call it themselves). Core NEVER reads the JVM-global
+ * OpenTelemetry accessor: that accessor lazily pins the global to a no-op (or reflectively
+ * autoconfigures an SDK) on first read, which would permanently kill tracing for any call that
+ * arrives before the consumer registers its SDK and would break the consumer's own later global
+ * registration. The per-call fast path here is a single volatile read + a reference compare against
+ * {@link OpenTelemetry#noop()} (see {@link #isNoop()}); install order does not matter — calls before
+ * install are untraced no-ops, calls after install trace. Full rationale: ADR-0006.
+ *
+ * <p>Shared instrumentation surface for the gRPC server/client interceptors and the HTTP handler:
+ * the kill-switch flag, the installed-{@link OpenTelemetry}-backed tracer/propagator, and a gRPC
+ * {@link Metadata} text-map getter/setter.
+ *
+ * <p><b>Relationship to ADR-0003 (MDC forwarding).</b> ADR-0003's pure-propagation path still
+ * forwards the inbound {@code traceparent} verbatim via MDC. When an SDK is installed, the client
+ * interceptor creates a real CLIENT span and injects a fresh {@code traceparent} for it;
+ * {@link #METADATA_SETTER} <em>overwrites</em> (removeAll + put) so the outbound carries exactly
+ * one {@code traceparent} reflecting the new client span — it supersedes the MDC-forwarded parent.
+ * With no SDK installed the interceptors short-circuit and inject nothing, so the MDC-forwarded
+ * {@code traceparent} survives unchanged: one header either way.
+ */
+public final class KrpcOtel {
+
+    private KrpcOtel() {}
+
+    /** Instrumentation scope name for krpc-created spans. */
+    public static final String SCOPE_NAME = "tech.krpc";
+
+    // RPC semantic-convention attribute keys. Hardcoded (not via the alpha opentelemetry-semconv
+    // artifact) so core depends on opentelemetry-api only — smaller surface, native-clean (NS-7).
+    public static final AttributeKey<String> RPC_SYSTEM  = AttributeKey.stringKey("rpc.system");
+    public static final AttributeKey<String> RPC_SERVICE = AttributeKey.stringKey("rpc.service");
+    public static final AttributeKey<String> RPC_METHOD  = AttributeKey.stringKey("rpc.method");
+    public static final AttributeKey<Long> RPC_GRPC_STATUS_CODE =
+            AttributeKey.longKey("rpc.grpc.status_code");
+    public static final String RPC_SYSTEM_GRPC = "grpc";
+
+    /** HTTP response status code (used by the http-server SERVER span). */
+    public static final AttributeKey<Long> HTTP_RESPONSE_STATUS_CODE =
+            AttributeKey.longKey("http.response.status_code");
+
+    // Kill-switch: rpc.otel.enabled (system property) or KRPC_OTEL (env), default ON. Default-ON is
+    // safe because instrumentation is a no-op without an OTel SDK (see class doc). Resolved once —
+    // the interceptors read this at registration, so the disabled path costs nothing per call.
+    private static final boolean ENABLED = resolveEnabled(
+            System.getProperty("rpc.otel.enabled"), System.getenv("KRPC_OTEL"));
+
+    /**
+     * Pure resolver (package-private for tests): explicit {@code false}/{@code 0} on either the
+     * system property or the env var disables; anything else (including unset) leaves it ON.
+     * The system property wins over the env var when both are set.
+     */
+    static boolean resolveEnabled(String prop, String env) {
+        if (prop != null && !prop.isBlank()) {
+            return !isFalse(prop);
+        }
+        if (env != null && !env.isBlank()) {
+            return !isFalse(env);
+        }
+        return true;
+    }
+
+    private static boolean isFalse(String v) {
+        v = v.trim();
+        return "false".equalsIgnoreCase(v) || "0".equals(v);
+    }
+
+    /** Kill-switch state. When false the interceptors are never registered (byte-level absent). */
+    public static boolean enabled() {
+        return ENABLED;
+    }
+
+    // The installed OpenTelemetry. Volatile: written once at integration startup, read per call.
+    // Default noop() so a consumer that never installs an SDK gets zero behavior + zero cost.
+    private static volatile OpenTelemetry otel = OpenTelemetry.noop();
+
+    /**
+     * Install the container's {@link OpenTelemetry} (Quarkus/Spring startup hooks pass the CDI/context
+     * bean; plain-netty users call this explicitly). Idempotent-safe: a null argument is ignored, and
+     * installing again simply replaces the reference (a plain volatile write). NEVER reads or writes
+     * the JVM-global OpenTelemetry accessor, so it cannot pin or conflict with the consumer's own global.
+     */
+    public static void install(OpenTelemetry openTelemetry) {
+        if (openTelemetry != null) {
+            otel = openTelemetry;
+        }
+    }
+
+    /**
+     * True until an SDK is {@link #install(OpenTelemetry) installed} — i.e. span creation is a no-op.
+     * The hot-path check: one volatile read + a reference compare against {@link OpenTelemetry#noop()}.
+     * Allocation-free, correct under any install-vs-request ordering, and never reads the JVM global.
+     */
+    public static boolean isNoop() {
+        return otel == OpenTelemetry.noop();
+    }
+
+    /** Tracer from the installed OpenTelemetry (a no-op tracer until an SDK is installed). */
+    public static Tracer tracer() {
+        return otel.getTracer(SCOPE_NAME);
+    }
+
+    /** W3C propagator from the installed OpenTelemetry (a no-op propagator until an SDK is installed). */
+    public static TextMapPropagator propagator() {
+        return otel.getPropagators().getTextMapPropagator();
+    }
+
+    /** Reads W3C headers from inbound gRPC {@link Metadata} for context extraction. */
+    public static final TextMapGetter<Metadata> METADATA_GETTER = new TextMapGetter<>() {
+        @Override
+        public Iterable<String> keys(Metadata carrier) {
+            return carrier == null ? java.util.List.of() : carrier.keys();
+        }
+
+        @Override
+        public String get(Metadata carrier, String key) {
+            if (carrier == null || key == null) {
+                return null;
+            }
+            return carrier.get(Metadata.Key.of(key, Metadata.ASCII_STRING_MARSHALLER));
+        }
+    };
+
+    /**
+     * Writes W3C headers to outbound gRPC {@link Metadata}. Overwrites (removeAll + put) so the
+     * carrier holds a single value per key — the OTel-injected {@code traceparent} supersedes any
+     * ADR-0003 MDC-forwarded one (see class doc).
+     */
+    public static final TextMapSetter<Metadata> METADATA_SETTER = (carrier, key, value) -> {
+        if (carrier == null || key == null || value == null) {
+            return;
+        }
+        var k = Metadata.Key.of(key, Metadata.ASCII_STRING_MARSHALLER);
+        carrier.removeAll(k);
+        carrier.put(k, value);
+    };
+}

--- a/rpc-common/src/test/java/tech/krpc/context/KrpcOtelTest.java
+++ b/rpc-common/src/test/java/tech/krpc/context/KrpcOtelTest.java
@@ -1,0 +1,72 @@
+package tech.krpc.context;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.grpc.Metadata;
+
+/**
+ * OTEL-001 (ADR-0006): unit contract for {@link KrpcOtel} — the kill-switch resolver and the gRPC
+ * metadata setter's single-value guarantee (the mechanism that keeps exactly one {@code traceparent}
+ * on the wire when OTel injection supersedes the ADR-0003 MDC-forwarded value).
+ */
+class KrpcOtelTest {
+
+    @Test
+    void resolveEnabled_defaultsOnWhenUnset() {
+        assertTrue(KrpcOtel.resolveEnabled(null, null), "unset must default ON");
+        assertTrue(KrpcOtel.resolveEnabled("  ", null), "blank prop must default ON");
+        assertTrue(KrpcOtel.resolveEnabled(null, ""), "blank env must default ON");
+    }
+
+    @Test
+    void resolveEnabled_explicitFalseOrZeroDisables() {
+        assertFalse(KrpcOtel.resolveEnabled("false", null));
+        assertFalse(KrpcOtel.resolveEnabled("FALSE", null));
+        assertFalse(KrpcOtel.resolveEnabled("0", null));
+        assertFalse(KrpcOtel.resolveEnabled(null, "false"));
+        assertFalse(KrpcOtel.resolveEnabled(null, "0"));
+    }
+
+    @Test
+    void resolveEnabled_anythingElseStaysOn() {
+        assertTrue(KrpcOtel.resolveEnabled("true", null));
+        assertTrue(KrpcOtel.resolveEnabled(null, "1"));
+        assertTrue(KrpcOtel.resolveEnabled("yes", null));
+    }
+
+    @Test
+    void resolveEnabled_systemPropertyWinsOverEnv() {
+        assertFalse(KrpcOtel.resolveEnabled("false", "true"), "prop false must win");
+        assertTrue(KrpcOtel.resolveEnabled("true", "false"), "prop true must win");
+    }
+
+    @Test
+    void metadataSetter_overwritesToSingleValue() {
+        Metadata md = new Metadata();
+        // Simulate an already-present (MDC-forwarded) traceparent, then an OTel injection.
+        KrpcOtel.METADATA_SETTER.set(md, "traceparent", "00-aaaa-bbbb-01");
+        KrpcOtel.METADATA_SETTER.set(md, "traceparent", "00-cccc-dddd-01");
+
+        List<String> values = new ArrayList<>();
+        var all = md.getAll(Metadata.Key.of("traceparent", Metadata.ASCII_STRING_MARSHALLER));
+        if (all != null) {
+            all.forEach(values::add);
+        }
+        assertEquals(List.of("00-cccc-dddd-01"), values,
+                "the setter must overwrite, leaving exactly one value (single traceparent on the wire)");
+    }
+
+    @Test
+    void metadataGetter_readsHeader() {
+        Metadata md = new Metadata();
+        md.put(Metadata.Key.of("traceparent", Metadata.ASCII_STRING_MARSHALLER), "00-eeee-ffff-01");
+        assertEquals("00-eeee-ffff-01", KrpcOtel.METADATA_GETTER.get(md, "traceparent"));
+    }
+}

--- a/rpc-server-quarkus/src/main/java/tech/krpc/server/quarkus/RpcServiceExpose.java
+++ b/rpc-server-quarkus/src/main/java/tech/krpc/server/quarkus/RpcServiceExpose.java
@@ -20,6 +20,8 @@ import tech.krpc.server.ServerContext;
 import tech.krpc.server.ServerFilter;
 import tech.krpc.server.exe.ThreadPool;
 import tech.krpc.util.EnvUtils;
+import tech.krpc.context.KrpcOtel;
+import io.opentelemetry.api.OpenTelemetry;
 import io.grpc.Server;
 import io.quarkus.runtime.Startup;
 import jakarta.annotation.PostConstruct;
@@ -72,6 +74,13 @@ public class RpcServiceExpose {//} extends SimpleBuildItem{
     @Inject
     tech.krpc.server.agent.McpToolRegistry mcpToolRegistry;
 
+    // OTEL-001 (ADR-0006): the container's OpenTelemetry, if the consumer's stack provides one
+    // (e.g. quarkus-opentelemetry). Optional Instance — absent (isResolvable()==false) when no OTel
+    // extension is present, in which case KrpcOtel stays no-op. @Startup runs after the container is
+    // fully initialized, so the bean (when present) is resolvable here.
+    @Inject
+    Instance<OpenTelemetry> openTelemetry;
+
     @ConfigProperty(name = "rpc.server.app")//,defaultValue = NULL
     Optional<String> app;
 
@@ -90,6 +99,15 @@ public class RpcServiceExpose {//} extends SimpleBuildItem{
 
     @PostConstruct
     public void expose() throws Exception {
+
+        // OTEL-001 (ADR-0006): explicitly install the container's OpenTelemetry into krpc (no global
+        // probing). Resolvable only when the consumer ships an OTel extension; otherwise stay no-op.
+        if (openTelemetry.isResolvable()) {
+            KrpcOtel.install(openTelemetry.get());
+            log.info("OTel: installed container OpenTelemetry into krpc (tracing active).");
+        } else {
+            log.debug("OTel: no OpenTelemetry bean present; krpc tracing stays no-op.");
+        }
 
         initFilter();
 

--- a/rpc-server-spring/src/main/java/tech/krpc/server/spring/RpcServiceExposer.java
+++ b/rpc-server-spring/src/main/java/tech/krpc/server/spring/RpcServiceExposer.java
@@ -31,6 +31,8 @@ import tech.krpc.server.ServerContext;
 import tech.krpc.server.ServerFilter;
 import tech.krpc.server.exe.ThreadPool;
 import tech.krpc.util.EnvUtils;
+import tech.krpc.context.KrpcOtel;
+import io.opentelemetry.api.OpenTelemetry;
 
 /**
  *
@@ -170,6 +172,13 @@ public class RpcServiceExposer implements ApplicationListener<ApplicationReadyEv
         initValidator();
 
         initJwsVerify.init();
+
+        // OTEL-001 (ADR-0006): explicitly install the Spring context's OpenTelemetry into krpc (no
+        // global probing). ifAvailable => absent (no OTel starter) leaves krpc no-op.
+        ctx.getBeanProvider(OpenTelemetry.class).ifAvailable(otel -> {
+            KrpcOtel.install(otel);
+            log.info("OTel: installed Spring OpenTelemetry into krpc (tracing active).");
+        });
 
         if (!defaultExecutor) {
             var name = app + "-rpc";

--- a/rpc-server/build.gradle
+++ b/rpc-server/build.gradle
@@ -1,6 +1,19 @@
 
 apply from: "$rootProject.projectDir/gradle/upload.gradle"
 
+// B1 (OTEL-001 / ADR-0006): a test source set whose runtimeClasspath EXCLUDES every OTel SDK
+// artifact (only opentelemetry-api via rpc-common). Proves the no-SDK fast path on a genuinely
+// SDK-free classpath — GlobalOpenTelemetry.get() is a real no-op here, not a resetForTest() fake.
+sourceSets {
+    noSdkTest {
+        compileClasspath += sourceSets.main.output
+        runtimeClasspath += sourceSets.main.output
+    }
+}
+configurations {
+    noSdkTestImplementation.extendsFrom implementation, api
+    noSdkTestRuntimeOnly.extendsFrom runtimeOnly
+}
 
 dependencies {
 
@@ -36,8 +49,34 @@ dependencies {
     testImplementation "org.junit.jupiter:junit-jupiter:5.11.4"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher"
     testImplementation "io.grpc:grpc-netty:${grpcVersion}"
+    // OTEL-001: in-process transport hop + OTel SDK test exporter (test scope only — no SDK in
+    // core runtime, NS-3). rpc-client on the test classpath drives the real client interceptor.
+    testImplementation "io.grpc:grpc-inprocess:${grpcVersion}"
+    testImplementation "io.opentelemetry:opentelemetry-sdk-testing:${otelVersion}"
+    testImplementation project(':rpc-client')
+
+    // B1: SDK-free source set — opentelemetry-api only (via rpc-common), NO sdk / sdk-testing.
+    noSdkTestImplementation "org.junit.jupiter:junit-jupiter:5.11.4"
+    noSdkTestRuntimeOnly "org.junit.platform:junit-platform-launcher"
+    noSdkTestImplementation "io.grpc:grpc-netty:${grpcVersion}"
+    noSdkTestImplementation "io.grpc:grpc-stub:${grpcVersion}"
+    noSdkTestImplementation project(':rpc-client')
+    // logback: real MDCAdapter so the ADR-0003 MDC parity assertion is exercisable.
+    noSdkTestRuntimeOnly "ch.qos.logback:logback-classic:1.5.18"
 }
 
 test {
     useJUnitPlatform()
+}
+
+tasks.register('noSdkTest', Test) {
+    description = 'OTEL-001 B1: runs the no-SDK fast-path tests on an OTel-SDK-free classpath.'
+    group = 'verification'
+    testClassesDirs = sourceSets.noSdkTest.output.classesDirs
+    classpath = sourceSets.noSdkTest.runtimeClasspath
+    useJUnitPlatform()
+}
+
+tasks.named('check') {
+    dependsOn 'noSdkTest'
 }

--- a/rpc-server/src/main/java/tech/krpc/server/OtelServerInterceptor.java
+++ b/rpc-server/src/main/java/tech/krpc/server/OtelServerInterceptor.java
@@ -1,0 +1,154 @@
+package tech.krpc.server;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import io.grpc.ForwardingServerCall;
+import io.grpc.ForwardingServerCallListener;
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.grpc.Status;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+
+import tech.krpc.context.KrpcOtel;
+
+/**
+ * ADR-0006: gRPC SERVER interceptor. Extracts the inbound W3C trace context from the call
+ * metadata, starts a SERVER span (child of the extracted remote span), and makes that span current
+ * on the thread that runs each listener callback — including {@code onHalfClose}, where krpc
+ * executes the handler on the app executor (a virtual thread; ADR-0002). So the handler and any
+ * outbound client call it makes see the SERVER span as their current context, keeping the trace
+ * connected across the hop.
+ *
+ * <p>OpenTelemetry API only (no SDK — ADR-0001 / NS-3). Until an SDK is installed
+ * ({@link KrpcOtel#install}), {@code isNoop()} is true and this interceptor is a pass-through —
+ * zero spans, zero wire change (NS-4). ADR-0003's MDC forwarding (parsed in
+ * {@link ServerContext}) is untouched and continues in parallel.
+ */
+public final class OtelServerInterceptor implements ServerInterceptor {
+
+    @Override
+    public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
+            ServerCall<ReqT, RespT> call, Metadata headers, ServerCallHandler<ReqT, RespT> next) {
+        // B1 (ADR-0006): no OTel SDK -> no-op TracerProvider. Skip all span-creation work and the
+        // listener/scope wrapping; the call proceeds untouched (zero allocation beyond this check).
+        if (KrpcOtel.isNoop()) {
+            return next.startCall(call, headers);
+        }
+
+        var descriptor = call.getMethodDescriptor();
+        Context parent = KrpcOtel.propagator()
+                .extract(Context.current(), headers, KrpcOtel.METADATA_GETTER);
+
+        Span span = KrpcOtel.tracer().spanBuilder(descriptor.getFullMethodName())
+                .setSpanKind(SpanKind.SERVER)
+                .setParent(parent)
+                .setAttribute(KrpcOtel.RPC_SYSTEM, KrpcOtel.RPC_SYSTEM_GRPC)
+                .setAttribute(KrpcOtel.RPC_SERVICE, nullToEmpty(descriptor.getServiceName()))
+                .setAttribute(KrpcOtel.RPC_METHOD, nullToEmpty(descriptor.getBareMethodName()))
+                .startSpan();
+
+        Context ctx = parent.with(span);
+        AtomicBoolean ended = new AtomicBoolean(false);
+
+        // Record the gRPC status on close; span ends on the terminal listener event (below).
+        var tracedCall = new ForwardingServerCall.SimpleForwardingServerCall<ReqT, RespT>(call) {
+            @Override
+            public void close(Status status, Metadata trailers) {
+                span.setAttribute(KrpcOtel.RPC_GRPC_STATUS_CODE, (long) status.getCode().value());
+                if (!status.isOk()) {
+                    span.setStatus(StatusCode.ERROR, status.getCode().name());
+                    if (status.getCause() != null) {
+                        span.recordException(status.getCause());
+                    }
+                }
+                super.close(status, trailers);
+            }
+        };
+
+        ServerCall.Listener<ReqT> listener;
+        try (Scope scope = ctx.makeCurrent()) {
+            listener = next.startCall(tracedCall, headers);
+        }
+        return new TracingServerCallListener<>(listener, ctx, span, ended);
+    }
+
+    private static String nullToEmpty(String s) {
+        return s == null ? "" : s;
+    }
+
+    /**
+     * Makes the SERVER-span context current for every listener callback — the callbacks run on the
+     * app executor, so this is what carries the span onto the handler's virtual thread — and ends
+     * the span exactly once on the terminal event ({@code onComplete} or {@code onCancel}).
+     */
+    private static final class TracingServerCallListener<ReqT>
+            extends ForwardingServerCallListener.SimpleForwardingServerCallListener<ReqT> {
+
+        private final Context ctx;
+        private final Span span;
+        private final AtomicBoolean ended;
+
+        TracingServerCallListener(ServerCall.Listener<ReqT> delegate, Context ctx, Span span,
+                                  AtomicBoolean ended) {
+            super(delegate);
+            this.ctx = ctx;
+            this.span = span;
+            this.ended = ended;
+        }
+
+        @Override
+        public void onMessage(ReqT message) {
+            try (Scope scope = ctx.makeCurrent()) {
+                super.onMessage(message);
+            }
+        }
+
+        @Override
+        public void onHalfClose() {
+            // krpc runs the handler here (on the app executor); the span must be current.
+            try (Scope scope = ctx.makeCurrent()) {
+                super.onHalfClose();
+            }
+        }
+
+        @Override
+        public void onReady() {
+            try (Scope scope = ctx.makeCurrent()) {
+                super.onReady();
+            }
+        }
+
+        @Override
+        public void onComplete() {
+            try (Scope scope = ctx.makeCurrent()) {
+                super.onComplete();
+            } finally {
+                endOnce();
+            }
+        }
+
+        @Override
+        public void onCancel() {
+            try (Scope scope = ctx.makeCurrent()) {
+                super.onCancel();
+            } finally {
+                if (ended.compareAndSet(false, true)) {
+                    span.setStatus(StatusCode.ERROR, Status.Code.CANCELLED.name());
+                    span.end();
+                }
+            }
+        }
+
+        private void endOnce() {
+            if (ended.compareAndSet(false, true)) {
+                span.end();
+            }
+        }
+    }
+}

--- a/rpc-server/src/main/java/tech/krpc/server/RpcServerBuilder.java
+++ b/rpc-server/src/main/java/tech/krpc/server/RpcServerBuilder.java
@@ -21,6 +21,7 @@ import tech.krpc.common.MethodStub;
 import tech.krpc.common.RpcConstants;
 import tech.krpc.common.RpcMetaService;
 import tech.krpc.common.meta.ApiMeta;
+import tech.krpc.context.KrpcOtel;
 import tech.krpc.filter.FilterInvokeHelper;
 import tech.krpc.util.RefUtils;
 import io.grpc.BindableService;
@@ -137,6 +138,13 @@ public class RpcServerBuilder {
 		//System.out.println("========XDS======XDS======XDS=====");
 
 		serverBuilder.executor(executor);
+
+		// OTEL-001 (ADR-0006): install the SERVER interceptor (W3C context extraction + SERVER
+		// span, scope-propagated to the handler's virtual thread). Default ON; a no-op until an OTel
+		// SDK is installed via KrpcOtel.install (zero spans, zero wire change). Off => not registered.
+		if (KrpcOtel.enabled()) {
+			serverBuilder.intercept(new OtelServerInterceptor());
+		}
 
 		// D2 (2026-07-03): app-layer defence-in-depth vs CVE-2026-47244 (HTTP/2
 		// stream-flood DoS). maxConcurrentCallsPerConnection lives only on

--- a/rpc-server/src/noSdkTest/java/tech/krpc/client/NoSdkClientFastPathTest.java
+++ b/rpc-server/src/noSdkTest/java/tech/krpc/client/NoSdkClientFastPathTest.java
@@ -1,0 +1,156 @@
+package tech.krpc.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
+
+import io.grpc.CallOptions;
+import io.grpc.ClientCall;
+import io.grpc.ManagedChannel;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+
+import tech.krpc.annotation.RpcService;
+import tech.krpc.common.MethodStub;
+import tech.krpc.context.KrpcOtel;
+import tech.krpc.context.TraceMeta;
+import tech.krpc.internal.InputProto;
+import tech.krpc.internal.OutputProto;
+import tech.krpc.internal.SerialEnum;
+import tech.krpc.model.RpcResult;
+
+/**
+ * OTEL-001 B1 (ADR-0006): proves the no-SDK fast path on a <b>genuinely SDK-free classpath</b> —
+ * this source set's runtimeClasspath carries {@code opentelemetry-api} only, no
+ * {@code opentelemetry-sdk}/{@code sdk-testing} (unlike the regular test suite, whose no-op relied
+ * on {@code resetForTest()} while the SDK was still on the classpath).
+ *
+ * <p>Asserts: the SDK really is absent; {@link KrpcOtel#isNoop()} is true; the client interceptor
+ * returns the delegate <b>unwrapped</b> (short-circuit branch taken — a cheap identity observable,
+ * not timing); and the outbound headers are byte-identical to the pre-OTEL ADR-0003 MDC behavior.
+ */
+class NoSdkClientFastPathTest {
+
+    @RpcService("NoSdkRpc")
+    interface NoSdkRpc {
+        RpcResult<String> echo(String s);
+    }
+
+    private static final class RecordingClientCall<Req, Resp> extends ClientCall<Req, Resp> {
+        volatile Metadata captured;
+
+        @Override public void start(Listener<Resp> l, Metadata headers) { this.captured = headers; }
+        @Override public void request(int n) {}
+        @Override public void cancel(String m, Throwable c) {}
+        @Override public void halfClose() {}
+        @Override public void sendMessage(Req m) {}
+    }
+
+    private static final class RecordingChannel extends ManagedChannel {
+        final RecordingClientCall<InputProto, OutputProto> call = new RecordingClientCall<>();
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <R, P> ClientCall<R, P> newCall(MethodDescriptor<R, P> md, CallOptions opts) {
+            return (ClientCall<R, P>) call;
+        }
+
+        @Override public String authority() { return "test-authority"; }
+        @Override public ManagedChannel shutdown() { return this; }
+        @Override public ManagedChannel shutdownNow() { return this; }
+        @Override public boolean isShutdown() { return false; }
+        @Override public boolean isTerminated() { return false; }
+        @Override public boolean awaitTermination(long t, TimeUnit u) { return true; }
+    }
+
+    @BeforeEach
+    void clearMdc() { MDC.clear(); }
+
+    @AfterEach
+    void afterMdc() { MDC.clear(); }
+
+    @Test
+    void otelSdkArtifactsAreAbsentFromClasspath() {
+        // The whole point of this source set: no SDK on the classpath (not merely reset-to-noop).
+        assertThrows(ClassNotFoundException.class,
+                () -> Class.forName("io.opentelemetry.sdk.OpenTelemetrySdk"),
+                "opentelemetry-sdk must NOT be on this test classpath");
+        assertThrows(ClassNotFoundException.class,
+                () -> Class.forName("io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter"),
+                "opentelemetry-sdk-testing must NOT be on this test classpath");
+    }
+
+    @Test
+    void isNoopIsTrueWithNoSdk() {
+        assertTrue(KrpcOtel.isNoop(),
+                "with no OTel SDK on the classpath, GlobalOpenTelemetry must resolve to a no-op TracerProvider");
+    }
+
+    @Test
+    void clientInterceptorReturnsDelegateUnwrapped_shortCircuitTaken() {
+        RecordingChannel channel = new RecordingChannel();
+        MethodDescriptor<InputProto, OutputProto> md = MethodStub.buildMd("NoSdkRpc/echo");
+
+        ClientCall<InputProto, OutputProto> result =
+                new OtelClientInterceptor().interceptCall(md, CallOptions.DEFAULT, channel);
+
+        // The no-op branch returns next.newCall(...) directly — the exact recorded delegate,
+        // never a TracingClientCall wrapper. Identity proves the short-circuit was taken.
+        assertSame(channel.call, result,
+                "no-SDK client interceptor must return the raw call unwrapped (no span-creating wrapper)");
+    }
+
+    @Test
+    void makeCall_noMdc_noTraceparent() throws Exception {
+        var invoker = invoker();
+        invoker.makeCall(CallOptions.DEFAULT).start(new ClientCall.Listener<>() {}, new Metadata());
+        assertTrue(traceparents().isEmpty(),
+                "no SDK + no MDC → no traceparent emitted");
+    }
+
+    @Test
+    void makeCall_mdcTraceparent_forwardedAsSingleHeader() throws Exception {
+        String parent = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01";
+        MDC.put(TraceMeta.MDC_TRACEPARENT, parent);
+
+        var invoker = invoker();
+        invoker.makeCall(CallOptions.DEFAULT).start(new ClientCall.Listener<>() {}, new Metadata());
+
+        assertEquals(List.of(parent), traceparents(),
+                "no SDK + MDC traceparent → exactly the MDC value on the wire (ADR-0003 byte parity)");
+    }
+
+    private RecordingChannel channel;
+
+    private MethodCallProxyHandler<NoSdkRpc>.ChannelMethodInvoker invoker() throws Exception {
+        channel = new RecordingChannel();
+        var handler = new MethodCallProxyHandler<>(
+                "no-sdk", channel, NoSdkRpc.class, List.of(), null, SerialEnum.JSON);
+        Method echo = NoSdkRpc.class.getMethod("echo", String.class);
+        var inv = handler.stubMap.get(echo);
+        assertNotNull(inv, "echo must have a wired invoker");
+        return inv;
+    }
+
+    private List<String> traceparents() {
+        assertNotNull(channel.call.captured, "the call must have been started");
+        List<String> out = new ArrayList<>();
+        var all = channel.call.captured.getAll(TraceMeta.TRACEPARENT_KEY);
+        if (all != null) {
+            all.forEach(out::add);
+        }
+        return out;
+    }
+}

--- a/rpc-server/src/noSdkTest/java/tech/krpc/server/NoSdkServerFastPathTest.java
+++ b/rpc-server/src/noSdkTest/java/tech/krpc/server/NoSdkServerFastPathTest.java
@@ -1,0 +1,58 @@
+package tech.krpc.server;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.Status;
+
+import tech.krpc.context.KrpcOtel;
+import tech.krpc.internal.InputProto;
+import tech.krpc.internal.OutputProto;
+
+/**
+ * OTEL-001 B1 (ADR-0006): the server interceptor's no-SDK fast path, on a genuinely SDK-free
+ * classpath (this source set carries {@code opentelemetry-api} only). Asserts {@link KrpcOtel#isNoop()}
+ * and that {@link OtelServerInterceptor} returns the delegate listener <b>unwrapped</b> — the
+ * short-circuit branch, observed by identity, so no span/scope/listener-wrapper is allocated.
+ */
+class NoSdkServerFastPathTest {
+
+    /** Minimal ServerCall stub; the no-op path never touches these (it delegates before reading them). */
+    private static final class StubServerCall extends ServerCall<InputProto, OutputProto> {
+        @Override public void request(int numMessages) {}
+        @Override public void sendHeaders(Metadata headers) {}
+        @Override public void sendMessage(OutputProto message) {}
+        @Override public void close(Status status, Metadata trailers) {}
+        @Override public boolean isCancelled() { return false; }
+        @Override public MethodDescriptor<InputProto, OutputProto> getMethodDescriptor() {
+            throw new AssertionError("no-op fast path must not read the method descriptor");
+        }
+    }
+
+    @Test
+    void isNoopIsTrueWithNoSdk() {
+        assertTrue(KrpcOtel.isNoop(),
+                "with no OTel SDK on the classpath, the server interceptor must see a no-op TracerProvider");
+    }
+
+    @Test
+    void serverInterceptorReturnsListenerUnwrapped_shortCircuitTaken() {
+        ServerCall.Listener<InputProto> sentinel = new ServerCall.Listener<>() {};
+        ServerCallHandler<InputProto, OutputProto> next = (call, headers) -> sentinel;
+
+        ServerCall.Listener<InputProto> result =
+                new OtelServerInterceptor().interceptCall(new StubServerCall(), new Metadata(), next);
+
+        // The no-op branch returns next.startCall(...) directly — the exact sentinel, never a
+        // TracingServerCallListener wrapper. Identity proves the short-circuit was taken; the
+        // StubServerCall.getMethodDescriptor() guard would fail loudly if the span path ran.
+        assertSame(sentinel, result,
+                "no-SDK server interceptor must return the raw listener unwrapped (no span-creating wrapper)");
+    }
+}

--- a/rpc-server/src/test/java/tech/krpc/server/OtelInstallOrderingTest.java
+++ b/rpc-server/src/test/java/tech/krpc/server/OtelInstallOrderingTest.java
@@ -1,0 +1,155 @@
+package tech.krpc.server;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.grpc.CallOptions;
+import io.grpc.ClientCall;
+import io.grpc.ManagedChannel;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.Status;
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
+import io.opentelemetry.context.propagation.ContextPropagators;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+
+import tech.krpc.client.OtelClientInterceptor;
+import tech.krpc.common.MethodStub;
+import tech.krpc.context.KrpcOtel;
+import tech.krpc.context.TraceMeta;
+import tech.krpc.internal.InputProto;
+import tech.krpc.internal.OutputProto;
+
+/**
+ * OTEL-001 B1c (ADR-0006): the install-vs-request ordering regression. Proves the r2 landmine is
+ * gone — core never reads the JVM-global {@code OpenTelemetry} accessor (which lazily pins the
+ * global to no-op on first read), so:
+ *
+ * <ul>
+ *   <li>a call intercepted while krpc is still no-op is untraced (no wrapper, no header) — the
+ *       "early call before the SDK arrives" case;
+ *   <li>after {@link KrpcOtel#install(OpenTelemetry)}, subsequent calls trace (wrapped + one
+ *       traceparent + a CLIENT span);
+ *   <li>the JVM global was never touched — a later {@code GlobalOpenTelemetry.set(...)} still
+ *       succeeds (would throw {@code IllegalStateException} if core had pinned it).
+ * </ul>
+ */
+class OtelInstallOrderingTest {
+
+    private static final MethodDescriptor<InputProto, OutputProto> MD =
+            MethodStub.buildMd("Ordering/echo");
+
+    private static final class RecordingClientCall<Req, Resp> extends ClientCall<Req, Resp> {
+        volatile Metadata captured;
+        volatile Listener<Resp> listener;
+
+        @Override public void start(Listener<Resp> l, Metadata headers) { this.listener = l; this.captured = headers; }
+        @Override public void request(int n) {}
+        @Override public void cancel(String m, Throwable c) {}
+        @Override public void halfClose() {}
+        @Override public void sendMessage(Req m) {}
+    }
+
+    private static final class RecordingChannel extends ManagedChannel {
+        final RecordingClientCall<InputProto, OutputProto> call = new RecordingClientCall<>();
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <R, P> ClientCall<R, P> newCall(MethodDescriptor<R, P> md, CallOptions opts) {
+            return (ClientCall<R, P>) call;
+        }
+
+        @Override public String authority() { return "test-authority"; }
+        @Override public ManagedChannel shutdown() { return this; }
+        @Override public ManagedChannel shutdownNow() { return this; }
+        @Override public boolean isShutdown() { return false; }
+        @Override public boolean isTerminated() { return false; }
+        @Override public boolean awaitTermination(long t, TimeUnit u) { return true; }
+    }
+
+    private OpenTelemetrySdk sdk;
+
+    @BeforeEach
+    void setUp() {
+        KrpcOtel.install(OpenTelemetry.noop());
+        GlobalOpenTelemetry.resetForTest(); // clean baseline; core never touches this anyway
+    }
+
+    @AfterEach
+    void tearDown() {
+        KrpcOtel.install(OpenTelemetry.noop());
+        if (sdk != null) {
+            sdk.getSdkTracerProvider().shutdown();
+            sdk = null;
+        }
+        GlobalOpenTelemetry.resetForTest();
+    }
+
+    @Test
+    void callBeforeInstallUntraced_callAfterInstallTraced_globalNeverPinned() {
+        var interceptor = new OtelClientInterceptor();
+
+        // 1) Early call while still no-op: unwrapped delegate, no traceparent emitted.
+        var earlyChannel = new RecordingChannel();
+        assertTrue(KrpcOtel.isNoop(), "krpc must start no-op before any install");
+        ClientCall<InputProto, OutputProto> early =
+                interceptor.interceptCall(MD, CallOptions.DEFAULT, earlyChannel);
+        assertSame(earlyChannel.call, early, "pre-install call must be unwrapped (untraced)");
+        early.start(new ClientCall.Listener<>() {}, new Metadata());
+        assertTrue(traceparents(earlyChannel).isEmpty(), "pre-install call must emit no traceparent");
+
+        // 2) Install an SDK later (simulating Quarkus registering after the first requests).
+        var exporter = InMemorySpanExporter.create();
+        SdkTracerProvider tp = SdkTracerProvider.builder()
+                .addSpanProcessor(SimpleSpanProcessor.create(exporter))
+                .build();
+        sdk = OpenTelemetrySdk.builder()
+                .setTracerProvider(tp)
+                .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.getInstance()))
+                .build();
+        KrpcOtel.install(sdk);
+        assertFalse(KrpcOtel.isNoop(), "after install krpc must trace");
+
+        // 3) Subsequent call traces: wrapped, one traceparent, a CLIENT span exported.
+        var lateChannel = new RecordingChannel();
+        ClientCall<InputProto, OutputProto> late =
+                interceptor.interceptCall(MD, CallOptions.DEFAULT, lateChannel);
+        assertNotSame(lateChannel.call, late, "post-install call must be wrapped (traced)");
+        late.start(new ClientCall.Listener<>() {}, new Metadata());
+        assertEquals(1, traceparents(lateChannel).size(), "post-install call must emit one traceparent");
+        lateChannel.call.listener.onClose(Status.OK, new Metadata()); // end the CLIENT span
+        assertEquals(1, exporter.getFinishedSpanItems().stream()
+                        .filter(s -> s.getKind() == io.opentelemetry.api.trace.SpanKind.CLIENT).count(),
+                "post-install call must export a CLIENT span");
+
+        // 4) The JVM global was never pinned by core: a later set() still succeeds (no ISE).
+        assertDoesNotThrow(() -> GlobalOpenTelemetry.set(sdk),
+                "core must never pin GlobalOpenTelemetry — a consumer's own set() must still work");
+    }
+
+    private static List<String> traceparents(RecordingChannel ch) {
+        List<String> out = new ArrayList<>();
+        var all = ch.call.captured.getAll(TraceMeta.TRACEPARENT_KEY);
+        if (all != null) {
+            all.forEach(out::add);
+        }
+        return out;
+    }
+}

--- a/rpc-server/src/test/java/tech/krpc/server/OtelProductionChainTest.java
+++ b/rpc-server/src/test/java/tech/krpc/server/OtelProductionChainTest.java
@@ -1,0 +1,236 @@
+package tech.krpc.server;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Server;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.context.propagation.ContextPropagators;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+
+import tech.krpc.annotation.RpcService;
+import tech.krpc.client.RpcClientFactory;
+import tech.krpc.context.KrpcOtel;
+import tech.krpc.context.TraceMeta;
+import tech.krpc.model.RpcResult;
+
+/**
+ * OTEL-001 B2 (ADR-0006): the production-chain container test. Two real krpc netty servers on
+ * loopback ports, stood up through the <b>production registration path</b>
+ * ({@link RpcServerBuilder} → {@code .intercept(OtelServerInterceptor)}), driven by real krpc
+ * clients ({@link RpcClientFactory} → {@code MethodCallProxyHandler} → {@code OtelClientInterceptor}
+ * + {@code PropagateTraceCall}). Order-service A's handler calls Ledger-service B over the wire.
+ *
+ * <p>Asserts the full chain under an in-process SDK exporter: inbound → SERVER-A → CLIENT → SERVER-B
+ * as one trace with correct parentage, exactly one {@code traceparent} on the A→B wire hop, and an
+ * exception path that ends the B-hop spans with ERROR status.
+ */
+class OtelProductionChainTest {
+
+    static final String APP = "otel-chain-it";
+
+    @RpcService("Ledger")
+    public interface LedgerService {
+        RpcResult<String> record(String note);
+        RpcResult<String> boom();
+    }
+
+    @RpcService("Order")
+    public interface OrderService {
+        RpcResult<String> place(String note);
+        RpcResult<String> placeFailing();
+    }
+
+    public static final class LedgerServiceImpl implements LedgerService {
+        final AtomicInteger inboundTraceparentCount = new AtomicInteger(-1);
+
+        @Override
+        public RpcResult<String> record(String note) {
+            // Count the traceparent headers actually received on the wire hop (must be exactly one).
+            var headers = ServerContext.current().getHeaders();
+            var all = headers.getAll(TraceMeta.TRACEPARENT_KEY);
+            int n = 0;
+            if (all != null) {
+                for (String ignored : all) {
+                    n++;
+                }
+            }
+            inboundTraceparentCount.set(n);
+            return RpcResult.ok("ledgered:" + note);
+        }
+
+        @Override
+        public RpcResult<String> boom() {
+            throw new RuntimeException("ledger down");
+        }
+    }
+
+    public static final class OrderServiceImpl implements OrderService {
+        private final LedgerService ledger;
+
+        OrderServiceImpl(LedgerService ledger) {
+            this.ledger = ledger;
+        }
+
+        @Override
+        public RpcResult<String> place(String note) {
+            var res = ledger.record(note);
+            return RpcResult.ok("ordered:" + res.getData());
+        }
+
+        @Override
+        public RpcResult<String> placeFailing() {
+            try {
+                ledger.boom();
+                return RpcResult.ok("unexpected-success");
+            } catch (RuntimeException e) {
+                // B failed over the wire; A completes cleanly so the assertion isolates the B-hop spans.
+                return RpcResult.error(13, "downstream ledger failed");
+            }
+        }
+    }
+
+    private InMemorySpanExporter exporter;
+    private SdkTracerProvider tracerProvider;
+    private OpenTelemetrySdk sdk;
+    private Server serverA;
+    private Server serverB;
+    private ManagedChannel channelA;
+    private ManagedChannel channelB;
+    private ExecutorService execA;
+    private ExecutorService execB;
+    private LedgerServiceImpl ledgerImpl;
+    private OrderService orderClient;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        KrpcOtel.install(OpenTelemetry.noop());
+        exporter = InMemorySpanExporter.create();
+        tracerProvider = SdkTracerProvider.builder()
+                .addSpanProcessor(SimpleSpanProcessor.create(exporter))
+                .build();
+        sdk = OpenTelemetrySdk.builder()
+                .setTracerProvider(tracerProvider)
+                .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.getInstance()))
+                .build();
+        KrpcOtel.install(sdk);
+
+        int portB = freePort();
+        execB = Executors.newVirtualThreadPerTaskExecutor();
+        ledgerImpl = new LedgerServiceImpl();
+        serverB = new RpcServerBuilder.Builder(APP, portB).executor(execB)
+                .addService(ledgerImpl).build().startServer();
+        channelB = ManagedChannelBuilder.forAddress("127.0.0.1", portB).usePlaintext().build();
+        LedgerService ledgerClient = new RpcClientFactory(APP, channelB).get(LedgerService.class);
+
+        int portA = freePort();
+        execA = Executors.newVirtualThreadPerTaskExecutor();
+        serverA = new RpcServerBuilder.Builder(APP, portA).executor(execA)
+                .addService(new OrderServiceImpl(ledgerClient)).build().startServer();
+        channelA = ManagedChannelBuilder.forAddress("127.0.0.1", portA).usePlaintext().build();
+        orderClient = new RpcClientFactory(APP, channelA).get(OrderService.class);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (channelA != null) channelA.shutdownNow();
+        if (channelB != null) channelB.shutdownNow();
+        if (serverA != null) serverA.shutdownNow();
+        if (serverB != null) serverB.shutdownNow();
+        if (execA != null) execA.shutdownNow();
+        if (execB != null) execB.shutdownNow();
+        if (tracerProvider != null) tracerProvider.shutdown();
+        KrpcOtel.install(OpenTelemetry.noop());
+    }
+
+    @Test
+    void inboundToOrderToLedgerIsOneTraceWithCorrectParentage() throws Exception {
+        Span root = sdk.getTracer("test")
+                .spanBuilder("inbound").setSpanKind(SpanKind.SERVER).startSpan();
+        RpcResult<String> res;
+        try (Scope scope = root.makeCurrent()) {
+            res = orderClient.place("x");
+        } finally {
+            root.end();
+        }
+        assertTrue(res.isOk(), () -> "order must succeed, got " + res.getCode() + " " + res.getMsg());
+
+        SpanData serverA = awaitSpan(SpanKind.SERVER, "/place");
+        SpanData clientRecord = awaitSpan(SpanKind.CLIENT, "/record");
+        SpanData serverB = awaitSpan(SpanKind.SERVER, "/record");
+        SpanData clientPlace = awaitSpan(SpanKind.CLIENT, "/place");
+
+        String trace = root.getSpanContext().getTraceId();
+        assertEquals(trace, clientPlace.getTraceId(), "CLIENT place must join the inbound trace");
+        assertEquals(trace, serverA.getTraceId(), "SERVER-A must join the inbound trace");
+        assertEquals(trace, clientRecord.getTraceId(), "CLIENT record must stay in the trace");
+        assertEquals(trace, serverB.getTraceId(), "SERVER-B must stay in the trace across the hop");
+
+        // Parent chain: inbound -> CLIENT place -> SERVER-A -> CLIENT record -> SERVER-B.
+        assertEquals(root.getSpanContext().getSpanId(), clientPlace.getParentSpanId());
+        assertEquals(clientPlace.getSpanId(), serverA.getParentSpanId());
+        assertEquals(serverA.getSpanId(), clientRecord.getParentSpanId(),
+                "the A->B CLIENT span must be a child of SERVER-A (context reached the handler)");
+        assertEquals(clientRecord.getSpanId(), serverB.getParentSpanId(),
+                "SERVER-B must be a child of the A->B CLIENT span (propagation across the wire hop)");
+
+        // Exactly one traceparent header on the A->B wire hop (OTel + MDC coexistence, no duplicate).
+        assertEquals(1, ledgerImpl.inboundTraceparentCount.get(),
+                "exactly one traceparent must reach service B on the wire");
+    }
+
+    @Test
+    void exceptionPathEndsHopSpansWithErrorStatus() throws Exception {
+        RpcResult<String> res = orderClient.placeFailing();
+        assertEquals(13, res.getCode(), "order must surface the downstream failure");
+
+        SpanData serverBoom = awaitSpan(SpanKind.SERVER, "/boom");
+        SpanData clientBoom = awaitSpan(SpanKind.CLIENT, "/boom");
+        assertEquals(StatusCode.ERROR, serverBoom.getStatus().getStatusCode(),
+                "SERVER-B span for a throwing handler must end with ERROR status");
+        assertEquals(StatusCode.ERROR, clientBoom.getStatus().getStatusCode(),
+                "the A->B CLIENT span must end with ERROR status when B fails");
+    }
+
+    private SpanData awaitSpan(SpanKind kind, String nameSuffix) throws InterruptedException {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+        while (System.nanoTime() < deadline) {
+            for (SpanData s : exporter.getFinishedSpanItems()) {
+                if (s.getKind() == kind && s.getName().endsWith(nameSuffix)) {
+                    return s;
+                }
+            }
+            Thread.sleep(25);
+        }
+        throw new AssertionError("no " + kind + " span ending '" + nameSuffix + "' in "
+                + exporter.getFinishedSpanItems());
+    }
+
+    private static int freePort() throws IOException {
+        try (ServerSocket ss = new ServerSocket(0)) {
+            return ss.getLocalPort();
+        }
+    }
+}

--- a/rpc-server/src/test/java/tech/krpc/server/OtelPropagationHopTest.java
+++ b/rpc-server/src/test/java/tech/krpc/server/OtelPropagationHopTest.java
@@ -1,0 +1,215 @@
+package tech.krpc.server;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientInterceptors;
+import io.grpc.ManagedChannel;
+import io.grpc.MethodDescriptor;
+import io.grpc.Server;
+import io.grpc.ServerServiceDefinition;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import io.grpc.inprocess.InProcessServerBuilder;
+import io.grpc.stub.ClientCalls;
+import io.grpc.stub.ServerCalls;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.context.propagation.ContextPropagators;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+
+import tech.krpc.context.KrpcOtel;
+
+/**
+ * OTEL-001 (ADR-0006): end-to-end trace propagation across a real in-process gRPC hop, using the
+ * production {@link OtelServerInterceptor} and {@code tech.krpc.client.OtelClientInterceptor} on a
+ * generic echo service. Defends the core contract:
+ *
+ * <ul>
+ *   <li>a root (inbound) context → CLIENT span (child) → injected {@code traceparent} → SERVER span
+ *       (child of the CLIENT span), all sharing one trace id — the P→C→S parent chain;
+ *   <li>the SERVER span is current on the handler thread (a virtual thread), so context reaches the
+ *       handler and any outbound call it makes.
+ * </ul>
+ */
+class OtelPropagationHopTest {
+
+    private static final MethodDescriptor.Marshaller<String> STRING_MARSHALLER =
+            new MethodDescriptor.Marshaller<>() {
+                @Override
+                public InputStream stream(String value) {
+                    return new ByteArrayInputStream(value.getBytes(StandardCharsets.UTF_8));
+                }
+
+                @Override
+                public String parse(InputStream stream) {
+                    try {
+                        return new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            };
+
+    private static final MethodDescriptor<String, String> ECHO =
+            MethodDescriptor.<String, String>newBuilder()
+                    .setType(MethodDescriptor.MethodType.UNARY)
+                    .setFullMethodName("krpc.test.Echo/echo")
+                    .setRequestMarshaller(STRING_MARSHALLER)
+                    .setResponseMarshaller(STRING_MARSHALLER)
+                    .build();
+
+    private InMemorySpanExporter exporter;
+    private SdkTracerProvider tracerProvider;
+    private OpenTelemetrySdk sdk;
+    private Server server;
+    private ManagedChannel channel;
+    private ExecutorService serverExecutor;
+
+    private final AtomicReference<SpanContext> handlerSpan = new AtomicReference<>();
+    private final AtomicBoolean handlerThreadVirtual = new AtomicBoolean(false);
+
+    @BeforeEach
+    void setUp() throws Exception {
+        KrpcOtel.install(OpenTelemetry.noop());
+        exporter = InMemorySpanExporter.create();
+        tracerProvider = SdkTracerProvider.builder()
+                .addSpanProcessor(SimpleSpanProcessor.create(exporter))
+                .build();
+        sdk = OpenTelemetrySdk.builder()
+                .setTracerProvider(tracerProvider)
+                .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.getInstance()))
+                .build();
+        KrpcOtel.install(sdk);
+
+        // Mirror production: the handler runs on the app executor (a virtual thread; ADR-0002).
+        serverExecutor = Executors.newVirtualThreadPerTaskExecutor();
+
+        ServerServiceDefinition service = ServerServiceDefinition.builder("krpc.test.Echo")
+                .addMethod(ECHO, ServerCalls.asyncUnaryCall((req, obs) -> {
+                    handlerThreadVirtual.set(Thread.currentThread().isVirtual());
+                    handlerSpan.set(Span.current().getSpanContext());
+                    obs.onNext(req);
+                    obs.onCompleted();
+                }))
+                .build();
+
+        String name = InProcessServerBuilder.generateName();
+        server = InProcessServerBuilder.forName(name)
+                .executor(serverExecutor)
+                .intercept(new OtelServerInterceptor())
+                .addService(service)
+                .build()
+                .start();
+        channel = InProcessChannelBuilder.forName(name).directExecutor().build();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (channel != null) {
+            channel.shutdownNow();
+        }
+        if (server != null) {
+            server.shutdownNow();
+        }
+        if (serverExecutor != null) {
+            serverExecutor.shutdownNow();
+        }
+        if (tracerProvider != null) {
+            tracerProvider.shutdown();
+        }
+        KrpcOtel.install(OpenTelemetry.noop());
+    }
+
+    @Test
+    void inboundContextFlowsThroughClientAndServerSpans() throws Exception {
+        Channel traced = ClientInterceptors.intercept(channel, new tech.krpc.client.OtelClientInterceptor());
+
+        Span root = sdk.getTracer("test")
+                .spanBuilder("inbound-root").setSpanKind(SpanKind.SERVER).startSpan();
+        String response;
+        try (Scope scope = root.makeCurrent()) {
+            response = ClientCalls.blockingUnaryCall(traced, ECHO, CallOptions.DEFAULT, "ping");
+        } finally {
+            root.end();
+        }
+        assertEquals("ping", response, "echo must round-trip the payload");
+
+        // The SERVER span ends asynchronously on the server side; await all three spans.
+        List<SpanData> spans = awaitSpans(3);
+
+        SpanData clientSpan = spanOfKind(spans, SpanKind.CLIENT);
+        SpanData serverSpan = spanOfKind(spans, SpanKind.SERVER, "krpc.test.Echo/echo");
+
+        // One trace across the whole hop.
+        assertEquals(root.getSpanContext().getTraceId(), clientSpan.getTraceId(),
+                "CLIENT span must join the inbound trace");
+        assertEquals(root.getSpanContext().getTraceId(), serverSpan.getTraceId(),
+                "SERVER span must join the inbound trace (traceparent extracted)");
+
+        // Parent chain: root -> client -> server.
+        assertEquals(root.getSpanContext().getSpanId(), clientSpan.getParentSpanId(),
+                "CLIENT span must be a child of the inbound span");
+        assertEquals(clientSpan.getSpanId(), serverSpan.getParentSpanId(),
+                "SERVER span must be a child of the CLIENT span (propagation across the hop)");
+
+        // rpc semantic conventions present.
+        assertEquals("grpc", serverSpan.getAttributes().get(KrpcOtel.RPC_SYSTEM));
+        assertEquals("krpc.test.Echo", serverSpan.getAttributes().get(KrpcOtel.RPC_SERVICE));
+        assertEquals("echo", serverSpan.getAttributes().get(KrpcOtel.RPC_METHOD));
+
+        // Scope propagated to the handler's virtual thread.
+        assertTrue(handlerThreadVirtual.get(), "handler must run on a virtual thread (ADR-0002)");
+        assertNotNull(handlerSpan.get());
+        assertTrue(handlerSpan.get().isValid(), "the SERVER span must be current inside the handler");
+        assertEquals(serverSpan.getSpanId(), handlerSpan.get().getSpanId(),
+                "the span current in the handler must be the SERVER span");
+    }
+
+    private List<SpanData> awaitSpans(int count) throws InterruptedException {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+        while (System.nanoTime() < deadline) {
+            if (exporter.getFinishedSpanItems().size() >= count) {
+                return exporter.getFinishedSpanItems();
+            }
+            Thread.sleep(20);
+        }
+        return exporter.getFinishedSpanItems();
+    }
+
+    private static SpanData spanOfKind(List<SpanData> spans, SpanKind kind) {
+        return spans.stream().filter(s -> s.getKind() == kind).findFirst()
+                .orElseThrow(() -> new AssertionError("no " + kind + " span exported; got " + spans));
+    }
+
+    private static SpanData spanOfKind(List<SpanData> spans, SpanKind kind, String name) {
+        return spans.stream().filter(s -> s.getKind() == kind && s.getName().equals(name))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("no " + kind + " span '" + name + "' in " + spans));
+    }
+}


### PR DESCRIPTION
## What

Adds the missing span-creation layer on krpc's self-owned netty faces (Quarkus auto-instrumentation cannot reach them — gRPC rides grpc-java's NettyServerHandler, HTTP rides krpc AbstractHttpHandler):

- **OtelServerInterceptor** (gRPC SERVER span, W3C extract, rpc semconv, VT-scoped)
- **OtelClientInterceptor** (CLIENT span + single traceparent injection)
- **AbstractHttpHandler** W3C context extraction + SERVER span (webhook/callback entry)

Core stays **OTel API-only** (`opentelemetry-api` + `-context`; no SDK/exporter — NS-3). No-op by construction without an SDK. `KrpcOtel` holds a volatile `OpenTelemetry` ref (default noop) with explicit `install()`; **no `GlobalOpenTelemetry` anywhere in core main** — probing it would pin the global to no-op if a request raced Quarkus's SDK registration. Quarkus wires via optional `Instance<OpenTelemetry>` at startup; Spring via `ObjectProvider`; plain-netty users call `KrpcOtel.install(...)` (documented). ADR-0006 records the design and amends ADR-0003's "no spans" clause. Rider: AGENT-001 roadmap entry corrected (P1 MCP bridge merged as #14, entry was stale).

## Review

Heterogeneous loop (omp exec / codex review) converged in 4 rounds: fake no-SDK proof (sdk-testing on classpath), hand-built harness masquerading as production-chain test, the GlobalOpenTelemetry pin-to-noop landmine, and a refuted "unverifiable locally" claim (quickstart IS a MySQL-free Quarkus consumer) — all closed with red-first probes. Final verdict APPROVE.

## Evidence

- 144 tests, 0 failures: rpc-common 25 · rpc-client 23 · rpc-server 62 · **rpc-server:noSdkTest 7** (real SDK-free classpath; interceptors return delegate by identity) · http-server 17 · examples:quickstart 10 (incl. @QuarkusTest positive-injection container test over a real gRPC call)
- Production-chain test: two real krpc netty servers, inbound→SERVER-A→CLIENT→SERVER-B one trace, exactly one traceparent on the wire, error-status path
- Install-ordering test: late install works; nothing pinned
- Native image built + booted (gRPC code 0 / HTTP 200) with the install wiring
- NOT verified locally: full OTLP export to a real backend (covered by LH staging E2E probe)