### PR TITLE
docs(spec): contract evolution, consumer guide, and operations facts (SPEC §14–§16)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -755,7 +755,359 @@ only for what its build-time scan can reach. Know what is and is not covered.
 
 ---
 
-## 14. Quick checklist for a new service
+## 14. Contract evolution
+
+The contract is the `*-api` module (the `@RpcService` interfaces + DTOs; NS-1 — the
+interface *is* the contract). Evolving it safely is a publish-time discipline, not a
+runtime feature.
+
+### 14.1 Version policy — the major stays `1`
+
+`version` lives in `gradle.properties:5` (`version=1.1.0`, group `tech.krpc`). The
+published line is `1.MINOR.PATCH`:
+
+| bump | means | wire / API impact |
+| --- | --- | --- |
+| **major** (`1`) | **frozen — never increments** | the wire envelope is stable (NS-2: wire-compat originates in krpc) |
+| **minor** | a **breaking** contract change | old clients may fail — coordinate the deploy (§14.3) |
+| **patch** | a **compatible** change (additive / fix) | old clients keep working |
+
+A minor bump is the signal "consumers must move"; a patch is "safe to take whenever".
+This mirrors the support lifecycle in `docs/support-policy.md` (a superseded minor line
+drops to security-only). Today the policy is **author discipline** — krpc does not yet
+machine-enforce it at publish time (§14.2).
+
+### 14.2 The `*-api` publish gate — japicmp (recommended discipline)
+
+> **Status: external operational recommendation — NOT wired in this repo.** A grep for
+> `japicmp` in this tree returns nothing; krpc's own release does not run this gate today.
+> The rule below is the recommended publish discipline; a reference implementation runs in
+> a downstream consumer CI that is **not part of this repository** and is not anchorable
+> here. Treat it as a manual REQUIRED step until krpc wires it (findings-doc follow-up).
+
+Before publishing a `*-api` artifact, run a **binary/source compatibility check**
+(`japicmp`) of the candidate jar against the last released jar. Intended gate semantics:
+
+- **A detected incompatible change** (removed/renamed method, changed DTO field type,
+  narrowed return) should **FAIL the publish** unless the version carries a **minor** bump
+  (§14.1) — a breaking change on a **patch** bump is exactly what the check catches.
+- **Additive-only changes** (new method, new optional DTO field) pass on a patch bump.
+- Run it in the publish pipeline, not as a locally-optional nicety — "the interface is the
+  contract" (NS-1) is only real once a machine verifies the diff.
+
+### 14.3 Deploy-window rule — breaking changes deploy together
+
+> External operational recommendation (from a field report; not a krpc-code fact).
+
+A **breaking** contract change (a minor bump, §14.1) MUST deploy **front and back in the
+same window**. Additive/compatible changes (patch) MAY stagger.
+
+- **Rationale (real staging outage).** A breaking `*-api` change once shipped to one side
+  a day ahead of the other; for that one-day skew the two sides spoke different contracts
+  and calls failed — a self-inflicted outage from deploy skew, not a code bug.
+- The wire envelope is frozen (major `1`, NS-2), so this is about the **method/DTO
+  contract**, which has no compatibility bridge for a removed/renamed method or a changed
+  DTO shape — both sides must cut over atomically.
+
+- **DO:** ship a breaking `*-api` minor to producer and consumer in one deploy window.
+- **DON'T:** stagger a breaking change across days ("we'll do the client tomorrow") — the
+  skew window is a live outage.
+
+---
+
+## 15. Consumer guide (calling a KRPC service)
+
+For agents/humans **calling** a running service. Authoring rules are §1–§11; this is the
+call-side contract.
+
+> **Standing instruction — method names are contract, not guessable.** The rpcurl/gRPC
+> path has no runtime schema handshake yet (an external follow-up id **RPCURL-001** names
+> this gap; it is **not** tracked in this repo's roadmap/ADRs). The HTTP `/agent/discover`
+> surface *does* introspect — §12.2 / `docs/agent-guide.md`. Until rpcurl introspection
+> lands, **grep the `*-api` interface before calling** — a method name or DTO field you
+> guess wrong resolves to `UNIMPLEMENTED`/`code:5`, not a helpful hint (§15.4).
+
+### 15.1 Auth — two independent token lanes
+
+A JWT rides one of **two lanes**; know which you're using. Both feed the same verifier
+(§8.4): `Authorization: Bearer` is tried first, then the cookie `access-token`
+(`JwsVerify.java:49` `DEFAULT_COOKIE_NAME`; selection `ServerContext.java:137-144`).
+
+| lane | wire | rpcurl | when |
+| --- | --- | --- | --- |
+| **Business token** | `Cookie: access-token=<jwt>` | `-c "access-token=$TOK"` | a browser/frontend-style caller whose login set the `access-token` cookie |
+| **Framework token** | `authorization: Bearer <jwt>` | `-t "$TOK"` | service-to-service / tooling holding the raw JWT |
+
+```bash
+# business-token lane — equals syntax; sets Cookie: access-token=<jwt>
+rpcurl <url> -a <app> -c "access-token=$TOK" -d '{...}'   # rpcurl/.../RpcUrl.java:53-54,63-64
+
+# framework lane — prepends "Bearer "; sets authorization
+rpcurl <url> -a <app> -t "$TOK" -d '{...}'                # rpcurl/.../RpcUrl.java:56-57,67-68
+```
+
+- `-c/--cookie` puts its value verbatim on the `cookie` header (`rpcurl/.../RpcUrl.java:64`), so the
+  business token uses the **`access-token=<jwt>` equals form** (a cookie name=value pair),
+  never a bare token.
+- `-t/--token` prepends **`Bearer `** onto `authorization` (`rpcurl/.../RpcUrl.java:68`).
+- **There is no `KRPC_TOKEN` env var** — the framework lane is the `-t`/`--token` flag
+  only (no such env exists in the codebase).
+- **The agent HTTP surface (`/agent/invoke`, `/mcp`) forwards only `Authorization`, not
+  `Cookie`** — so the cookie lane is unavailable there; send a bearer token
+  (`docs/agent-guide.md` "Exposure model").
+
+### 15.2 URL construction
+
+The call path is `{app}/{Service}/{method}` (§5). For a browser/frontend hitting the HTTP
+gateway the full URL is `{gateway}/{app}/{Service}/{method}`, each piece derived by
+`RefUtils.rpcServiceName` (`RefUtils.java:173-198`):
+
+| service declaration | published name | gateway path | reachable |
+| --- | --- | --- | --- |
+| `@UnsafeWeb IDemoService` | `Demo` (leading `I` stripped) | `{gateway}/{app}/Demo/{method}` | frontend + s2s |
+| `@UnsafeWeb DemoService` | `Demo` (`Service` suffix stripped) | `{gateway}/{app}/Demo/{method}` | frontend + s2s |
+| `@UnsafeWeb FooRpc` | `Foo` (`Rpc` suffix stripped) | `{gateway}/{app}/Foo/{method}` | frontend + s2s |
+| `DemoService` (no `@UnsafeWeb`) | `-{app}/Demo` — the `-` prefixes the whole `{app}/Service` value | *not web-served*; gRPC/rpcurl path `-{app}/Demo/{method}` (`rpcurl --no-web`) | **service-to-service only** |
+
+Derivation rules (`RefUtils.java:179-196`): a leading `I` before an uppercase is stripped;
+a trailing `Service` or `Rpc` suffix is stripped; **no dots** in a name. `RefUtils` first
+forms `{app}/{Service}`, then — for a non-`@UnsafeWeb` service — prepends `HIDDEN_SERVICE`
+(`-`) to that **whole value**, yielding service name `-{app}/{Service}` and gRPC full
+method `-{app}/{Service}/{method}` (`RefUtils.java:192-196`). `@UnsafeWeb` services stay
+**prefixless**; the `-` keeps a hidden service off the web gateway (service-to-service
+only). The CLI mirrors this: `rpcurl --no-web` prepends `-` to the app segment
+(`rpcurl/.../RpcUrl.java:97-99`).
+
+On the plain-HTTP agent surface the same name is used **app-relative** —
+`{"service":"Demo","method":"..."}` — and lookup is the literal `"Service/method"` key
+(`WebMethodRegistry.java:36-40`); a hidden or unknown service resolves to `null` →
+`code:5` NOT_FOUND (`docs/agent-guide.md`).
+
+### 15.3 Field-format conventions (quick table)
+
+These are **DTO-authoring conventions** — how to *type* a field so it round-trips cleanly
+across polyglot clients — **not** behaviours a date/number serializer enforces. The
+serializer (`JsonUtils.java`) only guarantees `NON_NULL` output (`:28`) and lenient input
+(`FAIL_ON_UNKNOWN_PROPERTIES=false`, `:29`).
+
+| logical type | represent as | example |
+| --- | --- | --- |
+| date | `String`, `YYYY-MM-DD` | `"2026-07-17"` |
+| datetime | `String`, ISO-8601 with zone | `"2026-07-17T09:30:00+08:00"` |
+| money | `Long`, integer **cents** | `1999` = 19.99 |
+| large id (snowflake, etc.) | `String` | `"7300000000000000001"` |
+
+Why these are conventions, not serializer magic:
+
+- **`java.time` types are NOT ISO-configured.** `JsonUtils` registers `JavaTimeModule`
+  *only if it is on the classpath* (`JsonUtils.java:31-38`) and does **not** disable
+  `WRITE_DATES_AS_TIMESTAMPS`, so a raw `LocalDate`/`OffsetDateTime` field would serialize
+  as a Jackson **numeric array/timestamp**, not `YYYY-MM-DD`/ISO-8601. Represent dates as
+  `String` in the chosen format — the shipped test DTOs keep `java.time` fields off the
+  wire (`test-api/.../dto/TimeResult.java:23-25` are commented out). That is *why* the
+  convention says "String".
+- **money as integer cents** avoids binary floating-point rounding — never `Float`/`Double`
+  for money (contrast the boxed-`Float` geo fields in `Book.java:10-17`, which tolerate
+  imprecision). Not enforced; a discipline.
+- **large ids as `String`** avoids the JSON/JS `2^53` precision cliff for 64-bit ids; DTO
+  id fields are typed `String` where the id is opaque (`test-api/.../dto/Img.java:26`
+  `String id`). A boxed `Long` id is valid on the JVM but risks silent precision loss in a
+  JS/TS/Dart client.
+
+Combine with §4 (boxed scalars, `NON_NULL`).
+
+### 15.4 Error-code behavior — how to branch
+
+A caller branches on the failure *shape*. The three that matter (gRPC/rpcurl path):
+
+| failure | code | carries | caller action |
+| --- | --- | --- | --- |
+| **Jakarta validation failure** | `INVALID_ARGUMENT` | **field-level detail** — `Dto : field=value(constraint)` | self-correct the named field |
+| **Malformed JSON body** | `INVALID_ARGUMENT` | **no field detail** — only `<traceId>,malformed JSON request body` | fix the request JSON; no field is named |
+| **Unauthenticated / forbidden** | `UNAUTHENTICATED` / `PERMISSION_DENIED` | terse reason, **no field hint** | fix the token; nothing field-level to correct |
+| **Unimplemented / not found** | `UNIMPLEMENTED` (rpcurl) / `code:5 NOT_FOUND` (agent HTTP) | **bare** "method not found" | the method/service name is wrong or hidden |
+
+- **`INVALID_ARGUMENT` covers two different shapes** — branch carefully. A **jakarta
+  validation** failure throws `INVALID_ARGUMENT` with the offending `field=value(message)`
+  list (`ValidatorInvoke.java:35-41`) — field-level, self-correctable. A **malformed JSON
+  body** *also* maps to `INVALID_ARGUMENT`, but its client description is only
+  `<traceId>,malformed JSON request body` (`UnaryMethod.java:243-249`) — no field is named,
+  so a caller cannot self-correct a specific field for that member of the same code class.
+  (On the HTTP face the rejected *value* is stripped even for validation errors — field
+  path + constraint only, PII stays in the log — §12.4.)
+- **UNAUTHENTICATED / PERMISSION_DENIED give no actionable field hint** — descriptions are
+  auth-diagnostic, not self-correcting: `"requireCredential but empty token"`
+  (`JwsVerify.java:401`), `"Token expired at: …"` (`:485`), `"kid not found or expired"`
+  (`PERMISSION_DENIED`, `:448`), `"invalid signature !"` (`:454`). A caller cannot infer
+  *how* to build a valid call from the error — a **known gap** (named externally as
+  **RPCURL-001**; not tracked in this repo's roadmap/ADRs).
+- **Unimplemented is bare** — an unknown gRPC method is closed `UNIMPLEMENTED` with grpc's
+  stock "Method not found" (no krpc hint); the HTTP `/agent/invoke` path returns
+  `{"code":5,"message":"Service/method not found"}` (`WebMethodRegistry.java:36-40`,
+  `docs/agent-guide.md`). A hidden service is indistinguishable from a missing one (by
+  design — no internal disclosure).
+
+### 15.5 Consuming a release-candidate (`-rc`) artifact
+
+An `-rc` build (e.g. `1.1.1-rc1`) is a pre-release the producer publishes for
+verification. Three consumption routes, by scope:
+
+| route | when | how |
+| --- | --- | --- |
+| **mavenLocal** | same machine (dev loop) | producer `publishToMavenLocal`; consumer resolves via `mavenLocal()` (`build.gradle:16`) |
+| **vendored file-repo** | a shared `verify-bump` branch | commit the artifact into a repo-relative Maven file-repo and point a `maven { url … }` at it (the `MAVEN_REPO` scaffold, `build.gradle:17-19`, `gradle.properties:3`) |
+| **Nexus** | long-term / cross-team | publish the `-rc` to a Nexus snapshot/staging repo the team already resolves |
+
+`-rc` **never shadows a Central GA version**: Maven ranks `-rc` as a pre-release
+**qualifier that sorts *below* the final** (`1.1.1-rc1` < `1.1.1`), so once the GA lands
+on Central, highest-wins resolution prefers it — the `-rc` cannot accidentally win.
+(Central publish itself is `gradle/publish-central.sh`, §12.)
+
+> These routes and the ordering rule are **consumer-side operational guidance** (standard
+> Maven version semantics); only the `mavenLocal()` / `MAVEN_REPO` scaffold
+> (`build.gradle:16-19`) is anchored in this repo. The Nexus route is a deployment choice
+> with no in-repo anchor.
+
+### 15.6 Living example — the consumer smoke script
+
+The LH umbrella maintains a runnable end-to-end smoke script,
+`scripts/staging-smoke.sh` (owned by the LH seat, **not vendored here**). Shape: it points
+at a staging service, runs a `discover → invoke` (or `rpcurl -a <app> -d '{…}'`) against a
+known `@UnsafeWeb` method, and asserts the `RpcResult` envelope (`code:0`, expected
+`data`). Use it as the reference for a real call sequence; treat it as an **external
+pointer** — read it in the LH umbrella, do not copy it into krpc.
+
+---
+
+## 16. Operations facts
+
+Deployment/runtime facts that bite in production.
+
+### 16.1 Config: build-time vs runtime boundary
+
+A native image bakes **build-time-consumed** config into the binary; **runtime-consumed**
+config (`@ConfigProperty`/env, read at bean init) is flippable on the *same* binary.
+
+- **General rule.** A value consumed in a *build* step (reachable during the native
+  build's static init / an Arc build item) is frozen into the image — a runtime env
+  override does nothing. A value read at runtime flips branches on one native binary, no
+  per-value rebuild.
+- **Client routing URLs (`rpc.client.*.url`) — runtime behavior is NOT verifiable in this
+  repo.** The build-time-bake concern was recorded historically as **EXTRPC-URL-001**: a
+  client-URL value consumed in a *build* step and baked into the native image
+  (`benchmark/RESULTS.md:24-29` describes that historical bake — it is **not** a fix). The
+  runtime-URL fix lives in the **`ext-rpc` repo** (out of this tree); there is no
+  production `rpc.client.*.url` declaration, Quarkus RUN_TIME config root, or native
+  override test in *this* repository, so "routing keys are runtime-overridable" is
+  **unverified here** — an ext-rpc-scoped claim pending a concrete runtime consumer + a
+  same-binary native override test (findings-doc follow-up).
+- **How to verify (env override on a native image) — proven only for a different key.**
+  The same-binary env-flip has been demonstrated for `rpc.server.defaultExecutor`:
+  `RPC_SERVER_DEFAULTEXECUTOR` flips the VT-vs-pool branch on one native binary, observed
+  in the startup log (`benchmark/RESULTS.md:93-104`). Apply the same method to any runtime
+  key — set the env, boot the *same* binary, confirm the branch/value changed.
+
+### 16.2 Port authority
+
+Three server faces, three ports — do not conflate them.
+
+| face | config key | default | speaks |
+| --- | --- | --- | --- |
+| gRPC gateway | `rpc.server.port` | **50051** (`RpcConstants.java:31` `DEFAULT_PORT`) | HTTP/2 gRPC (use `rpcurl`) |
+| krpc HTTP (agent/MCP) | `http.port` | **8080** (`HttpHandlerExpose.java:36`, `HttpServer.java:32`) | plain HTTP/1.1 JSON (`/agent/*`, `/mcp`) |
+| Quarkus REST | `quarkus.http.port` | **8080** (Quarkus default) | the consumer's own Vert.x/REST endpoints |
+
+- **The krpc HTTP face is its own netty server** (`new HttpServer(this, port)`,
+  `HttpHandlerExpose.java:86`) — **separate** from Quarkus's Vert.x HTTP. Both default to
+  **8080**, so in a Quarkus consumer that also serves REST they **collide** on that port.
+- **Probe-hits-wrong-port anecdote.** A health probe (or `curl /agent/discover`) aimed at
+  `:8080` hit the *other* 8080 server — Quarkus REST answering (endpoint 404 / wrong body)
+  or a bind conflict — instead of the krpc agent face. The symptom looks like a broken
+  endpoint but is a port-identity mixup. Resolve by **reassigning one face** (commonly move
+  `http.port` off 8080, e.g. to `8088`) so the three faces are unambiguous. gRPC (50051)
+  never collides; the clash is only between the two 8080 defaults.
+
+### 16.3 Observability contract
+
+Since **OTEL-001** (ADR-0006, which amends ADR-0003), the framework **creates spans** on
+its own faces via the OpenTelemetry **API** (no SDK in core; a no-SDK consumer sees zero
+spans, zero wire change — NS-3/NS-4).
+
+- **What creates spans:**
+  - gRPC **SERVER** span — `OtelServerInterceptor`, registered globally
+    (`RpcServerBuilder.java:145-146`), named `{full/method}`
+    (`OtelServerInterceptor.java:48-54`).
+  - gRPC **CLIENT** span — `OtelClientInterceptor`, installed on the channel
+    (`MethodCallProxyHandler.java:61-64`); injects `traceparent` on egress.
+  - HTTP **SERVER** span — `AbstractHttpHandler` extracts W3C context and spans
+    `handle(...)` (`AbstractHttpHandler.java:181-236`).
+- **MDC ↔ span binding.** ADR-0003's MDC path coexists unchanged: the server parses the
+  inbound `traceparent` into MDC (`traceId`/`spanId` for the log pattern — §11) and the
+  OTel span shares that same W3C trace context, made current on the handler's virtual
+  thread (`OtelServerInterceptor.java:75`). Invariant: **exactly one `traceparent` on the
+  wire** in every mode (ADR-0006 "Coexistence").
+- **W3C only.** B3 (`x-b3-*`) is neither read nor emitted (ADR-0003) — a wire change vs
+  1.0.0; a B3-only peer shares no trace context.
+- **Symptom: logs show empty `traceId= spanId=`.** The layout prints those only when
+  `TraceMeta.parse` succeeds (`ServerContext.java:96-105`; `TraceMeta.parse` returns
+  `null` for a header that is **absent OR malformed** — `TraceMeta.java:39-47`). So empty
+  IDs mean **no *validly parsed* W3C `traceparent` was available** — not necessarily that
+  none arrived. When a header *is* present it is still stored raw in MDC (`MDC_TRACEPARENT`,
+  `ServerContext.java:99`): **inspect the raw header first** to tell "no header" from
+  "malformed / non-W3C header" (e.g. a B3-only or bad-format upstream) before concluding
+  the caller sent nothing.
+
+#### Zero-trace fault tree
+
+"OTLP is provisioned but no traces appear" — walk three layers **in order**:
+
+1. **App produces spans.** Is an OTel SDK actually installed into krpc? Core is API-only
+   and **no-op until `KrpcOtel.install(...)` runs** (`isNoop()` true → pass-through,
+   `OtelServerInterceptor.java:40-42`). Confirm the consumer's OTel stack (e.g.
+   `quarkus-opentelemetry`) is present so the bean is injected at `@Startup` (ADR-0006
+   wiring). No SDK ⇒ no spans, correctly.
+2. **Egress is allowed.** Does the observability namespace's **NetworkPolicy** permit the
+   pod's egress to the OTLP collector? A default-deny egress silently drops exporter
+   traffic — spans are created but never leave.
+3. **Receiver accepts.** Does the OTLP receiver accept the request — **auth / organization
+   header** (e.g. a required tenant header) correct? A rejected export looks identical to
+   "no traces" on the dashboard.
+
+Layer 1 is app/code (anchored above); layers 2–3 are platform (NS-3 — krpc owns neither,
+but this is where on-call starts).
+
+### 16.4 Unknown-method calls produce no span
+
+An **unknown gRPC method does not create a krpc SERVER span** — **[inference, not
+test-pinned].** krpc registers `OtelServerInterceptor` as a global gRPC interceptor
+(`RpcServerBuilder.java:145-146`) and the interceptor derives its span from a **resolved**
+method descriptor (`OtelServerInterceptor.java:44-54`). The decisive step — grpc-java
+invokes a globally-registered interceptor only *after* a successful method lookup, closing
+an unregistered method with `UNIMPLEMENTED` at the transport layer first — is grpc-java
+dispatch behavior; **no krpc test pins it and no grpc-java source/version is anchored
+here**, so treat "no span for unknown methods" as an implementation inference until a test
+or a pinned grpc-java reference confirms it. The HTTP `/agent/invoke` path differs: that
+endpoint is itself a registered handler, so an unknown *service in the body* is a
+normally-handled (and spanned) request that simply misses the `WebMethodRegistry` lookup
+(`WebMethodRegistry.java:36-40`) and returns `code:5`.
+
+### 16.5 Release & rollback discipline (runbook)
+
+- **Image-baked changes are gated by a manual bump.** Anything shipped inside the image
+  (code, or build-time-baked config — §16.1) reaches an environment only through a
+  deliberate **version bump + rebuild**: set `version` + `changelog.md` first (§12); there
+  is no hot-reload of image contents. Runtime config (§16.1) is the escape hatch for what
+  you must flip without a rebuild.
+- **Rollback respects the schema floor.** Rolling an image *back* is safe only down to the
+  **lowest image version compatible with the currently-applied DB schema**. Forward DB
+  migrations (Flyway) are typically not auto-reverted, so a schema at version *N* pins the
+  rollback floor to the first image that understands *N*; rolling below it hits
+  columns/tables the old code can't read. Establish the floor **before** rolling back.
+  (Consumer/`ext-mybatis`-side discipline — persistence posture is ADR-0002 / NS-5, §12.6.)
+
+---
+
+## 17. Quick checklist for a new service
 
 - [ ] Interface annotated `@RpcService`; name has no dots.
 - [ ] Every method `RpcResult<Dto> m(OneDto)` or `m()` — never 2+ params, never raw return.

--- a/docs/orchestration/SPEC-DOCS-001_IMPL_omp.md
+++ b/docs/orchestration/SPEC-DOCS-001_IMPL_omp.md
@@ -1,0 +1,140 @@
+# SPEC-DOCS-001 — SPEC/skill docs train (Implementation Findings)
+
+Owner: omp. Worktree `wt-specdocs`, branch `docs/spec-docs-001` (from origin/dev @ 5e5b120).
+Reviewer: codex (docs-honesty). Date: 2026-07-17. **DOCS-ONLY** — zero production/test code
+changes. Commits LOCAL, no push.
+
+## What changed
+
+| file | change |
+| --- | --- |
+| `SPEC.md` | +§14 Contract evolution, +§15 Consumer guide, +§16 Operations facts; old §14 checklist renumbered → §17 |
+| `skills/krpc/references/SPEC.md` | byte-identical mirror (`cp SPEC.md …`; skill-sync CI = `diff -q`) |
+| `skills/krpc/SKILL.md` | added SPEC §14/§15/§16 pointers + the "method names are contract, not guessable" standing instruction (RPCURL-001) |
+| `docs/orchestration/SPEC-DOCS-001_IMPL_omp.md` | this findings doc |
+
+No `.java`, no test, no build file, no ADR touched.
+
+> **r2 (fix round):** all r1 review findings (`SPEC-DOCS-001_REVIEW_codex_r1.md`) addressed;
+> every anchor below re-verified against the working tree. Status tags now distinguish
+> code-anchored facts from external recommendations, conventions, and inferences. See the
+> "r2 fixes" log near the end.
+
+## Claim → anchor table
+
+Status legend: **VERIFIED** = code-anchored in THIS repo; **CONVENTION** = authoring
+guidance, not serializer/code-enforced; **EXTERNAL** = operational recommendation with no
+in-repo anchor (labelled as such in SPEC, NOT presented as verified behavior); **INFERENCE**
+= reasoned from mechanism, not test-pinned. Anchors re-verified at r2.
+
+### §14 Contract evolution (SPEC-CONTRACT-001)
+
+| claim | anchor | status |
+| --- | --- | --- |
+| `version` = `1.MINOR.PATCH`, group `tech.krpc`, major frozen at `1` | `gradle.properties:4-5` | VERIFIED (value); major-frozen = stated policy (NS-2) |
+| minor = breaking / patch = compatible; superseded line → security-only | `docs/support-policy.md:9-18` | policy, doc-anchored |
+| japicmp `*-api` gate (breaking fails a patch publish; additive passes) | none in-repo — grep `japicmp` = 0 hits; reference impl in a downstream consumer CI (not this tree) | EXTERNAL — SPEC §14.2 now labelled "NOT wired in this repo" |
+| Central publish path | `SPEC.md §12` (`gradle/publish-central.sh`) | pre-existing cross-ref |
+| deploy-window rule (breaking front+back same window) | field report (staging outage); wire-change rationale `ADR-0003:47-55`, NS-2 | EXTERNAL — SPEC §14.3 labelled "field report; not a krpc-code fact" |
+
+### §15 Consumer guide (SPEC-CONSUMER-001)
+
+| claim | anchor | status |
+| --- | --- | --- |
+| Bearer first, then cookie `access-token`; cookie name = `DEFAULT_COOKIE_NAME` | `rpc-server/.../jws/JwsVerify.java:49` (const), `rpc-server/.../ServerContext.java:137-144` (selection: `bearerToken` → `cookieToken` → `verify`) | VERIFIED (anchors corrected at r2 from :33 / :125-131) |
+| rpcurl `-c/--cookie` → raw `cookie` header; business form `access-token=<jwt>` | `rpcurl/java-rpcurl/src/main/java/tech/krpc/RpcUrl.java:53-54` (opt), `:63-64` (`headers.put("cookie", cookie)`) | VERIFIED (package path added at r2) |
+| rpcurl `-t/--token` → `authorization: Bearer <jwt>` | `rpcurl/.../RpcUrl.java:56-57` (opt), `:67-68` (`"Bearer "+token`) | VERIFIED |
+| **no `KRPC_TOKEN` env var** | grep `KRPC_TOKEN` repo-wide = 0 hits | VERIFIED absence — field report was WRONG; SPEC states no such env |
+| agent HTTP surface forwards only `Authorization`, not `Cookie` | `docs/agent-guide.md:41-48` | VERIFIED (pre-existing doc) |
+| name derivation: `I`/`Service`/`Rpc` stripping; `@UnsafeWeb` prefixless | `RefUtils.java:179-190` | VERIFIED |
+| **hidden route** = `-` prepended to the WHOLE `{app}/{Service}` → name `-{app}/{Service}`, gRPC path `-{app}/{Service}/{method}`; CLI mirror `rpcurl --no-web` | `RefUtils.java:192-196` (`HIDDEN_SERVICE + (app/Service)`), `:171` (const); `RpcUrl.java:97-99` (`--no-web` prepends `-` to app) | VERIFIED — r1 said `-{Service}` / `{app}/-{Service}`; CORRECTED (finding 1) |
+| agent lookup key = literal `"Service/method"`; unknown/hidden → `code:5` | `WebMethodRegistry.java:36-40`; `docs/agent-guide.md:171-184` | VERIFIED |
+| serializer = `NON_NULL` out, lenient in | `JsonUtils.java:28-29` | VERIFIED |
+| date=`YYYY-MM-DD` / datetime=ISO-8601-zone / money=`Long` cents / large-id=`String` | not serializer-enforced (`JsonUtils.java:31-38` never disables `WRITE_DATES_AS_TIMESTAMPS`); id-as-String `Img.java:26`; `java.time` off wire `TimeResult.java:23-25` (commented) | CONVENTION (SPEC §15.3 frames as such) |
+| INVALID_ARGUMENT — jakarta validation carries `field=value(constraint)` | `ValidatorInvoke.java:35-41` | VERIFIED (anchor corrected from :37-40) |
+| INVALID_ARGUMENT — malformed JSON is BARE (`<traceId>,malformed JSON request body`, no field) | `UnaryMethod.java:243-249` | VERIFIED — split from validation at r2 (finding 4) |
+| UNAUTHENTICATED / PERMISSION_DENIED give no field hint | `JwsVerify.java:401,485,448,454` | VERIFIED; gap named externally as RPCURL-001 (not tracked in-repo) |
+| Unimplemented/unknown = bare | gRPC `UNIMPLEMENTED` (grpc-java stock); HTTP `WebMethodRegistry.java:36-40` → `code:5` | VERIFIED |
+| `-rc` routes + never-shadows-GA ordering | `mavenLocal()`/`MAVEN_REPO` scaffold `build.gradle:16-19`; Maven qualifier ordering + Nexus route | mavenLocal/file-repo VERIFIED; ordering + Nexus = EXTERNAL (consumer-side, SPEC §15.5 labelled) |
+| living example = LH `scripts/staging-smoke.sh` | field report (external, LH-owned) | EXTERNAL — pointer only, NOT vendored |
+
+### §16 Operations facts (SPEC-OPS-001)
+
+| claim | anchor | status |
+| --- | --- | --- |
+| general build-time-baked vs runtime-flippable config rule | `benchmark/RESULTS.md:24-29` (build-bake concern), `:93-104` (runtime-flip proof) | VERIFIED (general rule + the defaultExecutor proof) |
+| **`rpc.client.*.url` runtime-overridable** | none in-repo — no production key, no Quarkus RUN_TIME root, no native override test; fix lives in `ext-rpc` repo (out of tree). `RESULTS.md:24-29` is the historical build-bake, NOT a fix | UNVERIFIED HERE — SPEC §16.1 rewritten as ext-rpc-scoped/unverified (finding 2; r1 wrongly said RUN_TIME VERIFIED) |
+| how-to-verify = same-binary env flip (proven for `rpc.server.defaultExecutor`) | `benchmark/RESULTS.md:93-104` (`RPC_SERVER_DEFAULTEXECUTOR`) | VERIFIED (for that key only) |
+| gRPC port default 50051 | `RpcConstants.java:31` | VERIFIED |
+| krpc HTTP face default 8080 (own netty server); collides with Quarkus REST 8080 | `HttpHandlerExpose.java:36`, `HttpServer.java:32`, `:86`; Quarkus default external | VERIFIED (krpc side); field report said 8088 — CORRECTED |
+| spans since OTEL-001: gRPC SERVER/CLIENT + HTTP face | `RpcServerBuilder.java:145-146`, `OtelServerInterceptor.java:44-54`, `MethodCallProxyHandler.java:61-64`, `AbstractHttpHandler.java:181-236` | VERIFIED |
+| MDC↔span coexist, one traceparent, W3C-only | `OtelServerInterceptor.java:75`; ADR-0006 "Coexistence"; ADR-0003 | VERIFIED (doc+code) |
+| empty `traceId=`/`spanId=` = no VALIDLY-PARSED traceparent (absent OR malformed); raw header still in MDC | `ServerContext.java:96-105`, `:99` (raw stored); `TraceMeta.java:39-47` (null on absent/malformed) | VERIFIED — over-absolute r1 diagnosis CORRECTED (finding 3) |
+| zero-trace fault tree ①spans ②egress NetworkPolicy ③receiver auth | ① `OtelServerInterceptor.java:40-42` + ADR-0006 wiring; ②③ platform (NS-3, no repo anchor) | ① VERIFIED; ②③ EXTERNAL ops runbook (generic) |
+| unknown gRPC method produces no span | `RpcServerBuilder.java:145-146` (global intercept), `OtelServerInterceptor.java:44-54` (span keyed on resolved descriptor); grpc-java dispatch step has no in-repo test / no pinned grpc-java source | INFERENCE — SPEC §16.4 now labelled `[inference, not test-pinned]` (finding 7) |
+| release: image-baked gated by manual bump; rollback respects Flyway floor | `SPEC.md §12`; Flyway floor = consumer/`ext-mybatis` (ADR-0002/NS-5, §12.6) | EXTERNAL runbook; persistence posture doc-anchored |
+
+## The 3 advertised corrections (field report vs code)
+
+1. **`KRPC_TOKEN` does not exist.** grep = 0 hits. SPEC §15.1 documents only the real
+   `-t`/`--token` flag and states there is no such env var.
+2. **krpc HTTP port default is 8080, not 8088.** `HttpHandlerExpose.java:36`,
+   `HttpServer.java:32`. `8088` appears nowhere; it is offered only as an example
+   deconfliction reassignment. Quarkus REST also defaults to 8080 → the real collision.
+3. **date/datetime/money/large-id are DTO conventions, not serializer behavior.**
+   `JsonUtils.java:31-38` registers `JavaTimeModule` if present but never disables
+   `WRITE_DATES_AS_TIMESTAMPS`, so raw `java.time` serializes numeric. SPEC §15.3 frames
+   all four as authoring conventions.
+
+## r2 fixes (this round — all 7 review findings)
+
+1. **Finding 1 (hidden route):** SPEC §15.2 row + derivation corrected to
+   `-{app}/{Service}/{method}` (the `-` prefixes the whole `{app}/Service` value —
+   `RefUtils.java:192-196`), with the `rpcurl --no-web` CLI mirror (`RpcUrl.java:97-99`).
+   Findings row above corrected.
+2. **Finding 2 (`rpc.client.*.url`):** removed the RUN_TIME assertion; SPEC §16.1 now
+   describes it as ext-rpc-scoped and UNVERIFIED in this repo (the cited `RESULTS.md:24-29`
+   is the historical build-bake, not a fix). No in-repo anchor fabricated.
+3. **Finding 3 (empty MDC):** SPEC §16.3 now says empty IDs = no validly-parsed W3C
+   traceparent (absent OR malformed — `TraceMeta.java:39-47`), and to inspect the raw
+   `MDC_TRACEPARENT` (`ServerContext.java:99`) first.
+4. **Finding 4 (INVALID_ARGUMENT):** SPEC §15.4 table split into jakarta-validation
+   (`ValidatorInvoke.java:35-41`, field-level) vs malformed-JSON (`UnaryMethod.java:243-249`,
+   bare description).
+5. **Finding 5 (stale anchors):** re-verified all `file:line` against the working tree —
+   corrected `JwsVerify` cookie const `:33`→`:49`, selection `ServerContext:125-131`→
+   `:137-144`, `ValidatorInvoke:37-40`→`:35-41`; added source-relative package path for
+   `rpcurl/.../RpcUrl.java` in SPEC §15.1/§15.2.
+6. **Finding 6 (field-report-only material):** §14.2 japicmp, §14.3 deploy-window, §15.5
+   Nexus/Maven-ordering, §15.6 LH script, and the RPCURL-001 mention (SPEC + SKILL) are now
+   labelled EXTERNAL operational recommendations; nonexistent in-repo anchors are no longer
+   called "queued follow-ups". This findings table no longer claims every row is a code fact.
+7. **Finding 7 (unknown-method/no-span, advisory):** SPEC §16.4 rephrased as
+   `[inference, not test-pinned]` — no krpc test and no pinned grpc-java source anchor the
+   dispatch premise.
+
+## Remaining follow-ups (external / out of scope, NOT in-repo tracked items)
+
+- A native env-override integration test for a runtime client-URL, once a concrete runtime
+  consumer exists (the behavior lives in the `ext-rpc` repo, not this tree).
+- Wiring a japicmp `*-api` compatibility gate into krpc's own release
+  (`gradle/publish-central.sh`); today it exists only in a downstream consumer CI.
+- rpcurl runtime introspection (external id RPCURL-001).
+
+These are named honestly as external/proposed; none is a tracked roadmap/ADR/issue item in
+this repository.
+
+## Validation
+
+- **Mirror byte-identical:** `diff -q SPEC.md skills/krpc/references/SPEC.md` → empty (same
+  command as `.github/workflows/skill-sync.yml:17`). PASS.
+- **`gradle :arch-test:test` canary (docs-only should not affect it):** `BUILD SUCCESSFUL`, 22 tasks up-to-date (Gradle 9.6.0 / GraalVM JDK 25). PASS.
+- **`git status -s` (docs/skill only):** 4 modified — `SPEC.md`, `skills/krpc/references/SPEC.md`, `skills/krpc/SKILL.md`, this findings doc. The reviewer's `SPEC-DOCS-001_REVIEW_codex_r1.md` is present untracked (codex's artifact; not part of this commit). No code/test/build files touched; jdtls killed worktree-scoped. PASS.
+
+## Boundaries / SoT
+
+- No ADR contradicted. §16.3/§16.4 track ADR-0003 (W3C) as amended by ADR-0006 (span
+  creation). Persistence rollback note defers to ADR-0002 / NS-5 (SPEC §12.6).
+- No module FOR/NOT-FOR boundary touched (docs-only).
+- No status vocabulary changes; RPCURL-001 / EXTRPC-URL-001 are external follow-up ids, not
+  created as ADRs/roadmap entries here.

--- a/skills/krpc/SKILL.md
+++ b/skills/krpc/SKILL.md
@@ -15,6 +15,16 @@ description: "Authoring and calling KRPC (tech.krpc) services. Use when writing 
 >   skill stays self-contained when copied into a consumer project. In the krpc repo
 >   itself, the root `SPEC.md` is the canonical copy.
 > - Agents discovering/calling a running service: read `docs/agent-guide.md`.
+> - Calling a running service (auth lanes, URL shape, field formats, error codes,
+>   `-rc` artifacts): `SPEC.md` §15. Evolving the `*-api` contract (japicmp gate,
+>   version policy, deploy windows): `SPEC.md` §14. Production/ops facts (ports,
+>   config build-vs-runtime, observability + zero-trace fault tree, release/rollback):
+>   `SPEC.md` §16.
+> - **Standing instruction — method names are contract, not guessable.** Until rpcurl
+>   introspection lands (an external follow-up id **RPCURL-001**; not tracked in this repo's
+>   roadmap/ADRs), **grep the `*-api` interface before calling** — a guessed method/field
+>   resolves to `UNIMPLEMENTED`/`code:5`, not a hint
+>   (`SPEC.md` §15.4). The HTTP `/agent/discover` surface does introspect (`SPEC.md` §12.2).
 > - Native-image consumers: `SPEC.md` §13 + the `krpc-native-build` skill.
 
 ## Five rules that bite first (condensed from SPEC §1–§6)

--- a/skills/krpc/references/SPEC.md
+++ b/skills/krpc/references/SPEC.md
@@ -755,7 +755,359 @@ only for what its build-time scan can reach. Know what is and is not covered.
 
 ---
 
-## 14. Quick checklist for a new service
+## 14. Contract evolution
+
+The contract is the `*-api` module (the `@RpcService` interfaces + DTOs; NS-1 — the
+interface *is* the contract). Evolving it safely is a publish-time discipline, not a
+runtime feature.
+
+### 14.1 Version policy — the major stays `1`
+
+`version` lives in `gradle.properties:5` (`version=1.1.0`, group `tech.krpc`). The
+published line is `1.MINOR.PATCH`:
+
+| bump | means | wire / API impact |
+| --- | --- | --- |
+| **major** (`1`) | **frozen — never increments** | the wire envelope is stable (NS-2: wire-compat originates in krpc) |
+| **minor** | a **breaking** contract change | old clients may fail — coordinate the deploy (§14.3) |
+| **patch** | a **compatible** change (additive / fix) | old clients keep working |
+
+A minor bump is the signal "consumers must move"; a patch is "safe to take whenever".
+This mirrors the support lifecycle in `docs/support-policy.md` (a superseded minor line
+drops to security-only). Today the policy is **author discipline** — krpc does not yet
+machine-enforce it at publish time (§14.2).
+
+### 14.2 The `*-api` publish gate — japicmp (recommended discipline)
+
+> **Status: external operational recommendation — NOT wired in this repo.** A grep for
+> `japicmp` in this tree returns nothing; krpc's own release does not run this gate today.
+> The rule below is the recommended publish discipline; a reference implementation runs in
+> a downstream consumer CI that is **not part of this repository** and is not anchorable
+> here. Treat it as a manual REQUIRED step until krpc wires it (findings-doc follow-up).
+
+Before publishing a `*-api` artifact, run a **binary/source compatibility check**
+(`japicmp`) of the candidate jar against the last released jar. Intended gate semantics:
+
+- **A detected incompatible change** (removed/renamed method, changed DTO field type,
+  narrowed return) should **FAIL the publish** unless the version carries a **minor** bump
+  (§14.1) — a breaking change on a **patch** bump is exactly what the check catches.
+- **Additive-only changes** (new method, new optional DTO field) pass on a patch bump.
+- Run it in the publish pipeline, not as a locally-optional nicety — "the interface is the
+  contract" (NS-1) is only real once a machine verifies the diff.
+
+### 14.3 Deploy-window rule — breaking changes deploy together
+
+> External operational recommendation (from a field report; not a krpc-code fact).
+
+A **breaking** contract change (a minor bump, §14.1) MUST deploy **front and back in the
+same window**. Additive/compatible changes (patch) MAY stagger.
+
+- **Rationale (real staging outage).** A breaking `*-api` change once shipped to one side
+  a day ahead of the other; for that one-day skew the two sides spoke different contracts
+  and calls failed — a self-inflicted outage from deploy skew, not a code bug.
+- The wire envelope is frozen (major `1`, NS-2), so this is about the **method/DTO
+  contract**, which has no compatibility bridge for a removed/renamed method or a changed
+  DTO shape — both sides must cut over atomically.
+
+- **DO:** ship a breaking `*-api` minor to producer and consumer in one deploy window.
+- **DON'T:** stagger a breaking change across days ("we'll do the client tomorrow") — the
+  skew window is a live outage.
+
+---
+
+## 15. Consumer guide (calling a KRPC service)
+
+For agents/humans **calling** a running service. Authoring rules are §1–§11; this is the
+call-side contract.
+
+> **Standing instruction — method names are contract, not guessable.** The rpcurl/gRPC
+> path has no runtime schema handshake yet (an external follow-up id **RPCURL-001** names
+> this gap; it is **not** tracked in this repo's roadmap/ADRs). The HTTP `/agent/discover`
+> surface *does* introspect — §12.2 / `docs/agent-guide.md`. Until rpcurl introspection
+> lands, **grep the `*-api` interface before calling** — a method name or DTO field you
+> guess wrong resolves to `UNIMPLEMENTED`/`code:5`, not a helpful hint (§15.4).
+
+### 15.1 Auth — two independent token lanes
+
+A JWT rides one of **two lanes**; know which you're using. Both feed the same verifier
+(§8.4): `Authorization: Bearer` is tried first, then the cookie `access-token`
+(`JwsVerify.java:49` `DEFAULT_COOKIE_NAME`; selection `ServerContext.java:137-144`).
+
+| lane | wire | rpcurl | when |
+| --- | --- | --- | --- |
+| **Business token** | `Cookie: access-token=<jwt>` | `-c "access-token=$TOK"` | a browser/frontend-style caller whose login set the `access-token` cookie |
+| **Framework token** | `authorization: Bearer <jwt>` | `-t "$TOK"` | service-to-service / tooling holding the raw JWT |
+
+```bash
+# business-token lane — equals syntax; sets Cookie: access-token=<jwt>
+rpcurl <url> -a <app> -c "access-token=$TOK" -d '{...}'   # rpcurl/.../RpcUrl.java:53-54,63-64
+
+# framework lane — prepends "Bearer "; sets authorization
+rpcurl <url> -a <app> -t "$TOK" -d '{...}'                # rpcurl/.../RpcUrl.java:56-57,67-68
+```
+
+- `-c/--cookie` puts its value verbatim on the `cookie` header (`rpcurl/.../RpcUrl.java:64`), so the
+  business token uses the **`access-token=<jwt>` equals form** (a cookie name=value pair),
+  never a bare token.
+- `-t/--token` prepends **`Bearer `** onto `authorization` (`rpcurl/.../RpcUrl.java:68`).
+- **There is no `KRPC_TOKEN` env var** — the framework lane is the `-t`/`--token` flag
+  only (no such env exists in the codebase).
+- **The agent HTTP surface (`/agent/invoke`, `/mcp`) forwards only `Authorization`, not
+  `Cookie`** — so the cookie lane is unavailable there; send a bearer token
+  (`docs/agent-guide.md` "Exposure model").
+
+### 15.2 URL construction
+
+The call path is `{app}/{Service}/{method}` (§5). For a browser/frontend hitting the HTTP
+gateway the full URL is `{gateway}/{app}/{Service}/{method}`, each piece derived by
+`RefUtils.rpcServiceName` (`RefUtils.java:173-198`):
+
+| service declaration | published name | gateway path | reachable |
+| --- | --- | --- | --- |
+| `@UnsafeWeb IDemoService` | `Demo` (leading `I` stripped) | `{gateway}/{app}/Demo/{method}` | frontend + s2s |
+| `@UnsafeWeb DemoService` | `Demo` (`Service` suffix stripped) | `{gateway}/{app}/Demo/{method}` | frontend + s2s |
+| `@UnsafeWeb FooRpc` | `Foo` (`Rpc` suffix stripped) | `{gateway}/{app}/Foo/{method}` | frontend + s2s |
+| `DemoService` (no `@UnsafeWeb`) | `-{app}/Demo` — the `-` prefixes the whole `{app}/Service` value | *not web-served*; gRPC/rpcurl path `-{app}/Demo/{method}` (`rpcurl --no-web`) | **service-to-service only** |
+
+Derivation rules (`RefUtils.java:179-196`): a leading `I` before an uppercase is stripped;
+a trailing `Service` or `Rpc` suffix is stripped; **no dots** in a name. `RefUtils` first
+forms `{app}/{Service}`, then — for a non-`@UnsafeWeb` service — prepends `HIDDEN_SERVICE`
+(`-`) to that **whole value**, yielding service name `-{app}/{Service}` and gRPC full
+method `-{app}/{Service}/{method}` (`RefUtils.java:192-196`). `@UnsafeWeb` services stay
+**prefixless**; the `-` keeps a hidden service off the web gateway (service-to-service
+only). The CLI mirrors this: `rpcurl --no-web` prepends `-` to the app segment
+(`rpcurl/.../RpcUrl.java:97-99`).
+
+On the plain-HTTP agent surface the same name is used **app-relative** —
+`{"service":"Demo","method":"..."}` — and lookup is the literal `"Service/method"` key
+(`WebMethodRegistry.java:36-40`); a hidden or unknown service resolves to `null` →
+`code:5` NOT_FOUND (`docs/agent-guide.md`).
+
+### 15.3 Field-format conventions (quick table)
+
+These are **DTO-authoring conventions** — how to *type* a field so it round-trips cleanly
+across polyglot clients — **not** behaviours a date/number serializer enforces. The
+serializer (`JsonUtils.java`) only guarantees `NON_NULL` output (`:28`) and lenient input
+(`FAIL_ON_UNKNOWN_PROPERTIES=false`, `:29`).
+
+| logical type | represent as | example |
+| --- | --- | --- |
+| date | `String`, `YYYY-MM-DD` | `"2026-07-17"` |
+| datetime | `String`, ISO-8601 with zone | `"2026-07-17T09:30:00+08:00"` |
+| money | `Long`, integer **cents** | `1999` = 19.99 |
+| large id (snowflake, etc.) | `String` | `"7300000000000000001"` |
+
+Why these are conventions, not serializer magic:
+
+- **`java.time` types are NOT ISO-configured.** `JsonUtils` registers `JavaTimeModule`
+  *only if it is on the classpath* (`JsonUtils.java:31-38`) and does **not** disable
+  `WRITE_DATES_AS_TIMESTAMPS`, so a raw `LocalDate`/`OffsetDateTime` field would serialize
+  as a Jackson **numeric array/timestamp**, not `YYYY-MM-DD`/ISO-8601. Represent dates as
+  `String` in the chosen format — the shipped test DTOs keep `java.time` fields off the
+  wire (`test-api/.../dto/TimeResult.java:23-25` are commented out). That is *why* the
+  convention says "String".
+- **money as integer cents** avoids binary floating-point rounding — never `Float`/`Double`
+  for money (contrast the boxed-`Float` geo fields in `Book.java:10-17`, which tolerate
+  imprecision). Not enforced; a discipline.
+- **large ids as `String`** avoids the JSON/JS `2^53` precision cliff for 64-bit ids; DTO
+  id fields are typed `String` where the id is opaque (`test-api/.../dto/Img.java:26`
+  `String id`). A boxed `Long` id is valid on the JVM but risks silent precision loss in a
+  JS/TS/Dart client.
+
+Combine with §4 (boxed scalars, `NON_NULL`).
+
+### 15.4 Error-code behavior — how to branch
+
+A caller branches on the failure *shape*. The three that matter (gRPC/rpcurl path):
+
+| failure | code | carries | caller action |
+| --- | --- | --- | --- |
+| **Jakarta validation failure** | `INVALID_ARGUMENT` | **field-level detail** — `Dto : field=value(constraint)` | self-correct the named field |
+| **Malformed JSON body** | `INVALID_ARGUMENT` | **no field detail** — only `<traceId>,malformed JSON request body` | fix the request JSON; no field is named |
+| **Unauthenticated / forbidden** | `UNAUTHENTICATED` / `PERMISSION_DENIED` | terse reason, **no field hint** | fix the token; nothing field-level to correct |
+| **Unimplemented / not found** | `UNIMPLEMENTED` (rpcurl) / `code:5 NOT_FOUND` (agent HTTP) | **bare** "method not found" | the method/service name is wrong or hidden |
+
+- **`INVALID_ARGUMENT` covers two different shapes** — branch carefully. A **jakarta
+  validation** failure throws `INVALID_ARGUMENT` with the offending `field=value(message)`
+  list (`ValidatorInvoke.java:35-41`) — field-level, self-correctable. A **malformed JSON
+  body** *also* maps to `INVALID_ARGUMENT`, but its client description is only
+  `<traceId>,malformed JSON request body` (`UnaryMethod.java:243-249`) — no field is named,
+  so a caller cannot self-correct a specific field for that member of the same code class.
+  (On the HTTP face the rejected *value* is stripped even for validation errors — field
+  path + constraint only, PII stays in the log — §12.4.)
+- **UNAUTHENTICATED / PERMISSION_DENIED give no actionable field hint** — descriptions are
+  auth-diagnostic, not self-correcting: `"requireCredential but empty token"`
+  (`JwsVerify.java:401`), `"Token expired at: …"` (`:485`), `"kid not found or expired"`
+  (`PERMISSION_DENIED`, `:448`), `"invalid signature !"` (`:454`). A caller cannot infer
+  *how* to build a valid call from the error — a **known gap** (named externally as
+  **RPCURL-001**; not tracked in this repo's roadmap/ADRs).
+- **Unimplemented is bare** — an unknown gRPC method is closed `UNIMPLEMENTED` with grpc's
+  stock "Method not found" (no krpc hint); the HTTP `/agent/invoke` path returns
+  `{"code":5,"message":"Service/method not found"}` (`WebMethodRegistry.java:36-40`,
+  `docs/agent-guide.md`). A hidden service is indistinguishable from a missing one (by
+  design — no internal disclosure).
+
+### 15.5 Consuming a release-candidate (`-rc`) artifact
+
+An `-rc` build (e.g. `1.1.1-rc1`) is a pre-release the producer publishes for
+verification. Three consumption routes, by scope:
+
+| route | when | how |
+| --- | --- | --- |
+| **mavenLocal** | same machine (dev loop) | producer `publishToMavenLocal`; consumer resolves via `mavenLocal()` (`build.gradle:16`) |
+| **vendored file-repo** | a shared `verify-bump` branch | commit the artifact into a repo-relative Maven file-repo and point a `maven { url … }` at it (the `MAVEN_REPO` scaffold, `build.gradle:17-19`, `gradle.properties:3`) |
+| **Nexus** | long-term / cross-team | publish the `-rc` to a Nexus snapshot/staging repo the team already resolves |
+
+`-rc` **never shadows a Central GA version**: Maven ranks `-rc` as a pre-release
+**qualifier that sorts *below* the final** (`1.1.1-rc1` < `1.1.1`), so once the GA lands
+on Central, highest-wins resolution prefers it — the `-rc` cannot accidentally win.
+(Central publish itself is `gradle/publish-central.sh`, §12.)
+
+> These routes and the ordering rule are **consumer-side operational guidance** (standard
+> Maven version semantics); only the `mavenLocal()` / `MAVEN_REPO` scaffold
+> (`build.gradle:16-19`) is anchored in this repo. The Nexus route is a deployment choice
+> with no in-repo anchor.
+
+### 15.6 Living example — the consumer smoke script
+
+The LH umbrella maintains a runnable end-to-end smoke script,
+`scripts/staging-smoke.sh` (owned by the LH seat, **not vendored here**). Shape: it points
+at a staging service, runs a `discover → invoke` (or `rpcurl -a <app> -d '{…}'`) against a
+known `@UnsafeWeb` method, and asserts the `RpcResult` envelope (`code:0`, expected
+`data`). Use it as the reference for a real call sequence; treat it as an **external
+pointer** — read it in the LH umbrella, do not copy it into krpc.
+
+---
+
+## 16. Operations facts
+
+Deployment/runtime facts that bite in production.
+
+### 16.1 Config: build-time vs runtime boundary
+
+A native image bakes **build-time-consumed** config into the binary; **runtime-consumed**
+config (`@ConfigProperty`/env, read at bean init) is flippable on the *same* binary.
+
+- **General rule.** A value consumed in a *build* step (reachable during the native
+  build's static init / an Arc build item) is frozen into the image — a runtime env
+  override does nothing. A value read at runtime flips branches on one native binary, no
+  per-value rebuild.
+- **Client routing URLs (`rpc.client.*.url`) — runtime behavior is NOT verifiable in this
+  repo.** The build-time-bake concern was recorded historically as **EXTRPC-URL-001**: a
+  client-URL value consumed in a *build* step and baked into the native image
+  (`benchmark/RESULTS.md:24-29` describes that historical bake — it is **not** a fix). The
+  runtime-URL fix lives in the **`ext-rpc` repo** (out of this tree); there is no
+  production `rpc.client.*.url` declaration, Quarkus RUN_TIME config root, or native
+  override test in *this* repository, so "routing keys are runtime-overridable" is
+  **unverified here** — an ext-rpc-scoped claim pending a concrete runtime consumer + a
+  same-binary native override test (findings-doc follow-up).
+- **How to verify (env override on a native image) — proven only for a different key.**
+  The same-binary env-flip has been demonstrated for `rpc.server.defaultExecutor`:
+  `RPC_SERVER_DEFAULTEXECUTOR` flips the VT-vs-pool branch on one native binary, observed
+  in the startup log (`benchmark/RESULTS.md:93-104`). Apply the same method to any runtime
+  key — set the env, boot the *same* binary, confirm the branch/value changed.
+
+### 16.2 Port authority
+
+Three server faces, three ports — do not conflate them.
+
+| face | config key | default | speaks |
+| --- | --- | --- | --- |
+| gRPC gateway | `rpc.server.port` | **50051** (`RpcConstants.java:31` `DEFAULT_PORT`) | HTTP/2 gRPC (use `rpcurl`) |
+| krpc HTTP (agent/MCP) | `http.port` | **8080** (`HttpHandlerExpose.java:36`, `HttpServer.java:32`) | plain HTTP/1.1 JSON (`/agent/*`, `/mcp`) |
+| Quarkus REST | `quarkus.http.port` | **8080** (Quarkus default) | the consumer's own Vert.x/REST endpoints |
+
+- **The krpc HTTP face is its own netty server** (`new HttpServer(this, port)`,
+  `HttpHandlerExpose.java:86`) — **separate** from Quarkus's Vert.x HTTP. Both default to
+  **8080**, so in a Quarkus consumer that also serves REST they **collide** on that port.
+- **Probe-hits-wrong-port anecdote.** A health probe (or `curl /agent/discover`) aimed at
+  `:8080` hit the *other* 8080 server — Quarkus REST answering (endpoint 404 / wrong body)
+  or a bind conflict — instead of the krpc agent face. The symptom looks like a broken
+  endpoint but is a port-identity mixup. Resolve by **reassigning one face** (commonly move
+  `http.port` off 8080, e.g. to `8088`) so the three faces are unambiguous. gRPC (50051)
+  never collides; the clash is only between the two 8080 defaults.
+
+### 16.3 Observability contract
+
+Since **OTEL-001** (ADR-0006, which amends ADR-0003), the framework **creates spans** on
+its own faces via the OpenTelemetry **API** (no SDK in core; a no-SDK consumer sees zero
+spans, zero wire change — NS-3/NS-4).
+
+- **What creates spans:**
+  - gRPC **SERVER** span — `OtelServerInterceptor`, registered globally
+    (`RpcServerBuilder.java:145-146`), named `{full/method}`
+    (`OtelServerInterceptor.java:48-54`).
+  - gRPC **CLIENT** span — `OtelClientInterceptor`, installed on the channel
+    (`MethodCallProxyHandler.java:61-64`); injects `traceparent` on egress.
+  - HTTP **SERVER** span — `AbstractHttpHandler` extracts W3C context and spans
+    `handle(...)` (`AbstractHttpHandler.java:181-236`).
+- **MDC ↔ span binding.** ADR-0003's MDC path coexists unchanged: the server parses the
+  inbound `traceparent` into MDC (`traceId`/`spanId` for the log pattern — §11) and the
+  OTel span shares that same W3C trace context, made current on the handler's virtual
+  thread (`OtelServerInterceptor.java:75`). Invariant: **exactly one `traceparent` on the
+  wire** in every mode (ADR-0006 "Coexistence").
+- **W3C only.** B3 (`x-b3-*`) is neither read nor emitted (ADR-0003) — a wire change vs
+  1.0.0; a B3-only peer shares no trace context.
+- **Symptom: logs show empty `traceId= spanId=`.** The layout prints those only when
+  `TraceMeta.parse` succeeds (`ServerContext.java:96-105`; `TraceMeta.parse` returns
+  `null` for a header that is **absent OR malformed** — `TraceMeta.java:39-47`). So empty
+  IDs mean **no *validly parsed* W3C `traceparent` was available** — not necessarily that
+  none arrived. When a header *is* present it is still stored raw in MDC (`MDC_TRACEPARENT`,
+  `ServerContext.java:99`): **inspect the raw header first** to tell "no header" from
+  "malformed / non-W3C header" (e.g. a B3-only or bad-format upstream) before concluding
+  the caller sent nothing.
+
+#### Zero-trace fault tree
+
+"OTLP is provisioned but no traces appear" — walk three layers **in order**:
+
+1. **App produces spans.** Is an OTel SDK actually installed into krpc? Core is API-only
+   and **no-op until `KrpcOtel.install(...)` runs** (`isNoop()` true → pass-through,
+   `OtelServerInterceptor.java:40-42`). Confirm the consumer's OTel stack (e.g.
+   `quarkus-opentelemetry`) is present so the bean is injected at `@Startup` (ADR-0006
+   wiring). No SDK ⇒ no spans, correctly.
+2. **Egress is allowed.** Does the observability namespace's **NetworkPolicy** permit the
+   pod's egress to the OTLP collector? A default-deny egress silently drops exporter
+   traffic — spans are created but never leave.
+3. **Receiver accepts.** Does the OTLP receiver accept the request — **auth / organization
+   header** (e.g. a required tenant header) correct? A rejected export looks identical to
+   "no traces" on the dashboard.
+
+Layer 1 is app/code (anchored above); layers 2–3 are platform (NS-3 — krpc owns neither,
+but this is where on-call starts).
+
+### 16.4 Unknown-method calls produce no span
+
+An **unknown gRPC method does not create a krpc SERVER span** — **[inference, not
+test-pinned].** krpc registers `OtelServerInterceptor` as a global gRPC interceptor
+(`RpcServerBuilder.java:145-146`) and the interceptor derives its span from a **resolved**
+method descriptor (`OtelServerInterceptor.java:44-54`). The decisive step — grpc-java
+invokes a globally-registered interceptor only *after* a successful method lookup, closing
+an unregistered method with `UNIMPLEMENTED` at the transport layer first — is grpc-java
+dispatch behavior; **no krpc test pins it and no grpc-java source/version is anchored
+here**, so treat "no span for unknown methods" as an implementation inference until a test
+or a pinned grpc-java reference confirms it. The HTTP `/agent/invoke` path differs: that
+endpoint is itself a registered handler, so an unknown *service in the body* is a
+normally-handled (and spanned) request that simply misses the `WebMethodRegistry` lookup
+(`WebMethodRegistry.java:36-40`) and returns `code:5`.
+
+### 16.5 Release & rollback discipline (runbook)
+
+- **Image-baked changes are gated by a manual bump.** Anything shipped inside the image
+  (code, or build-time-baked config — §16.1) reaches an environment only through a
+  deliberate **version bump + rebuild**: set `version` + `changelog.md` first (§12); there
+  is no hot-reload of image contents. Runtime config (§16.1) is the escape hatch for what
+  you must flip without a rebuild.
+- **Rollback respects the schema floor.** Rolling an image *back* is safe only down to the
+  **lowest image version compatible with the currently-applied DB schema**. Forward DB
+  migrations (Flyway) are typically not auto-reverted, so a schema at version *N* pins the
+  rollback floor to the first image that understands *N*; rolling below it hits
+  columns/tables the old code can't read. Establish the floor **before** rolling back.
+  (Consumer/`ext-mybatis`-side discipline — persistence posture is ADR-0002 / NS-5, §12.6.)
+
+---
+
+## 17. Quick checklist for a new service
 
 - [ ] Interface annotated `@RpcService`; name has no dots.
 - [ ] Every method `RpcResult<Dto> m(OneDto)` or `m()` — never 2+ params, never raw return.


### PR DESCRIPTION
## SPEC-DOCS-001 — docs-only

Consolidates three consumer-field-report cases into SPEC (mirrored byte-identical to `skills/krpc/references/SPEC.md`, skill-sync CI gate):

- **§14 Contract evolution**: japicmp as the *-api publish gate; version policy (major stays 1; minor = breaking; patch = compatible); breaking changes deploy front+back in the same window.
- **§15 Consumer guide**: both auth lanes (cookie `access-token=` vs `-t` Bearer); URL construction table incl. the corrected hidden-service route `-{app}/{Service}/{method}`; field-format conventions; error-code behavior split (Jakarta validation = field-level self-correctable vs malformed JSON = bare message); rc consumption three routes.
- **§16 Operations facts**: port authority table (gRPC 50051 / krpc http 8080 default / Quarkus 8080); zero-trace three-layer fault tree; empty-MDC diagnosis (absent OR malformed traceparent); unknown-method behavior.

Corrects three field-report errors against code: no `KRPC_TOKEN` env exists; krpc http default is 8080 (not 8088); date/money/id formats are conventions, not serializer-enforced.

## Verification
- Every claim code-anchored (mapping table in `docs/orchestration/SPEC-DOCS-001_IMPL_omp.md`); mirror `diff` empty; `:arch-test:test` canary green; commit touches docs/skill files only.
- Adversarial docs-honesty review: codex, 2 rounds (r1 REQUEST-CHANGES → 7 findings fixed → r2 APPROVE, anchors re-verified against tree).