### PR TITLE
fix(otel): HTTP→outbound trace binding + sensitive-header redaction (OTEL-002)

### DIFF
--- a/docs/orchestration/OTEL-002_IMPL_omp.md
+++ b/docs/orchestration/OTEL-002_IMPL_omp.md
@@ -1,0 +1,185 @@
+# OTEL-002 — Implementation & Findings (omp)
+
+Branch `fix/otel-002` off `origin/dev @ 5e5b120` (the OTEL-001 merge, #23). Reviewer: codex.
+Scope: three field-found OTel/logging defects from staging rc1 + red-first tests + this doc.
+No wire change (NS-4); OTel = API-only, no SDK in core (NS-3); touched main sources native-clean (NS-7).
+
+Baseline confirmed green before changes: `OtelProductionChainTest`, `HttpOtelSpanTest`.
+Round 2 folds in the codex r1 review (R1-1..R1-8); see the per-finding section at the end.
+
+---
+
+## Fix 1 — HTTP inbound context does not reach outbound krpc client calls
+
+### Root cause (verified, not the premise's guess)
+
+The premise guessed the HTTP SERVER span "is not made current around the handler body". **False** —
+OTEL-001 already binds the OTel SERVER span across `handle(...)` via `span.makeCurrent()`, proven by
+`HttpOtelSpanTest` and by my SDK-mode `HttpToKrpcClientChainTest` (green on dev).
+
+The real defect: the **ADR-0003 MDC trace binding the HTTP face never performed**. The gRPC face
+binds inbound W3C context into MDC in `ServerContext` (`ServerContext.java:96-107`) and clears it in
+`UnaryMethod`; the HTTP face bound only the OTel span. Consequences:
+
+1. **No-SDK deployments lose the trace on outbound calls.** With no SDK, continuity relies solely on
+   ADR-0003 MDC forwarding: `MethodCallProxyHandler.makeCall` (`:138-142`) reads
+   `MDC.get(MDC_TRACEPARENT)` and wraps the call in `PropagateTraceCall`. Empty MDC → no
+   `PropagateTraceCall` → downstream gets no `traceparent` → new trace.
+2. **Handler logs carried no `traceId`/`spanId`.**
+
+### Fix
+`AbstractHttpHandler.bindTraceMdc(...)` mirrors `ServerContext`'s inbound binding, called before the
+handler body; `MDC.clear()` in `finally`. Independent of OTel span creation. Hardened per r1:
+
+- **R1-4 (strict validation):** only a fully valid W3C `traceparent` is bound/forwarded.
+  `TraceMeta.parse` now strictly validates lower-case hex, field lengths, version ≠ `ff`, and
+  non-zero trace/span ids; malformed or absent → **no** trace MDC keys set → zero outbound
+  `traceparent` (never an incoherent one). Valid → exactly one.
+- **R1-5 (MDC identifies the active span):** once the HTTP SERVER span is current (SDK mode), logging
+  MDC `traceId`/`spanId` are overwritten from **its** `SpanContext`, so a handler error log joins the
+  span that recorded the error. The inbound `traceparent` is retained in MDC only for the no-SDK
+  legacy forward.
+- **R1-8 (async boundary):** documented on `bindTraceMdc` — the MDC/OTel scope covers the
+  **synchronous** handler body only; work a handler schedules onto its own executor/`CompletableFuture`
+  after `handle()` returns must capture/propagate context itself (out of the framework's scope).
+
+### Tests
+- `HttpTraceMdcPropagationTest` (no SDK, logback): valid → forwarded once; **absent → 0**;
+  **malformed → 0** (R1-4); **duplicate header → exactly 1**. `validInbound...` is the red-first
+  case (RED `expected:1 but was:0` on dev).
+- `HttpToKrpcClientChainTest` (SDK): full SERVER→CLIENT→SERVER chain + exactly-one-traceparent;
+  `capturedHandlerMdcIdentifiesTheHttpServerSpan` asserts handler MDC == exported SERVER span id, not
+  the inbound parent (R1-5).
+
+---
+
+## Fix 2 — "ghost CLIENT spans": OPEN at the independent A/B export boundary; in-process lifecycle excluded
+
+### Field report
+Downstream SERVER spans reference CLIENT span-ids as parent, but no CLIENT span body reaches the
+backend; traceId continuity intact.
+
+### What the in-process test establishes (and what it does NOT — R1-6)
+`GhostClientSpanTest` rebuilds `BatchSpanProcessor` (async flush) + `parentBased(alwaysOn)` +
+`forceFlush`, versus OTEL-001's `SimpleSpanProcessor`, and shows the CLIENT span body **is exported
+with correct parentage** on both the sync (`blockingUnaryCall`) and async (`asyncUnaryCall`,
+`@Deprecated AsyncClient`) paths (exception path already covered by `OtelProductionChainTest`).
+
+**This excludes an in-process krpc span-lifecycle bug ONLY under shared-pipeline assumptions.** It
+does not reproduce the field's independent A/B boundary: A and B share one `OpenTelemetrySdk`/
+exporter here and the flush always succeeds. It therefore cannot exercise:
+- A exporting its CLIENT span through a **separate** OTLP pipeline/collector while B exports its
+  SERVER span through its own;
+- an **A-side batch queue drop** (queue full / exporter error);
+- **A pod termination before its BatchSpanProcessor drains** (no successful flush).
+
+Any of these produces exactly the field signature (B's SERVER references A's injected CLIENT id;
+A's CLIENT body never arrives), and none is reachable from a single-process shared-exporter test.
+
+### Sampler-flag argument — qualified (R1-6)
+"A sampler dropping the CLIENT span would also unsample the downstream, so the field's intact
+downstream implies the CLIENT was sampled" holds **only if service B uses parent-based head
+sampling**: a non-recording CLIENT context injects flag `00` and the default
+remote-parent-not-sampled branch drops B's span. Under independent or tail sampling at B this
+argument does not hold, so it cannot by itself exclude the report.
+
+### Conclusion / cutover gate
+No speculative fix shipped (先量再改). The ghost is **OPEN** at the independent export/flush boundary
+and is gated on the consumer's staging window (they offered live repro access + A-side
+exporter/collector delivery evidence for the reported trace). Cutover gate includes "CLIENT span
+body appears in the backend for the reproduced trace". A two-process/container rig with separate A/B
+SDK+exporter pipelines and staging collector config (including termination without a successful
+flush) is the correct reproduction; it is **not** shipped in this repo (deliberately — it would be a
+staging/infra artifact, not a core unit test). `GhostClientSpanTest` is retained as a regression
+guard, relabelled to state precisely what it proves.
+
+---
+
+## Fix 3 — sensitive-header redaction (JWT plaintext in DEBUG logs)
+
+### Policy: MASK BY DEFAULT (R1-2)
+`tech.krpc.util.LogRedact` (rpc-common — shared by both faces). A deny-list cannot make a full
+arbitrary-header dump safe (the next unlisted `X-Token`/`X-Goog-Api-Key`/custom auth header leaks),
+so every header value is **masked** (`<redacted>`, a fixed sentinel — never a prefix of the secret)
+UNLESS its name is on an explicit `DIAGNOSTIC_SAFE` allow-list (content negotiation/framing,
+`user-agent`/`host`/`connection`/`date`/`cache-control`, `traceparent`/`tracestate`/`x-request-id`,
+`mcp-protocol-version`/`c-id`/`x-krpc-http-status`). `cookie`/`set-cookie` keep cookie **names** and
+mask every value; a bare (`=`-less) non-empty segment is masked whole (R1-3 — it may itself be the
+secret).
+
+### Application
+`AbstractHttpHandler` logs inbound requests at DEBUG through `redactHeaders` (lower-cased keys,
+masked values). **R1-1:** only the raw **path** (`QueryStringDecoder(uri).rawPath()`) is logged, never
+the query string (which can carry `?access_token=...`).
+
+### Audit table
+
+| Site | Emits | Action |
+|---|---|---|
+| `AbstractHttpHandler` inbound log (`:126`) | raw path + headers/cookies | path-only + `LogRedact` (mask-by-default) |
+| `AbstractHttpHandler:~421` `Parse Post Json` | request **body** (DEBUG) | residual — see below |
+| `ServerContext`/`UnaryMethod` (gRPC) | method setup, MDC clear | no full metadata dump — none needed |
+| `JwsVerify`/auth path | url, JWKS kids, error messages | no token value logged — none needed |
+| `InitJwsVerify` | cookie **name** (config) | not a value — none needed |
+| marshallers, `AsyncMethod:106` | sizes, code/message | no credential — none needed |
+
+### Residual (documented, out of header scope)
+`AbstractHttpHandler` `Parse Post Json` logs the raw POST body at DEBUG. Bodies are app DTO content
+the framework cannot classify per-field; DEBUG is off in prod by default (observability env matrix).
+A follow-up could add DTO field-level masking. Out of scope for this hotfix.
+
+### Tests
+- `LogRedactTest` (8): default-deny for `Authorization` + unlisted token-shaped names
+  (`X-Token`/`X-Goog-Api-Key`/...), allow-list pass-through, cookie name-keep/value-mask, **bare
+  segment masked** (R1-3), case-insensitivity, null-safety.
+- `HttpHeaderRedactionTest` (4): captures the **fully rendered encoder output** (`%mdc` + `%msg`,
+  R1-7); masks Authorization + `access-token` cookie; **query credential not logged** (R1-1);
+  **unlisted `X-Token`/`X-Goog-Api-Key` masked** (R1-2); no live token in any rendered line.
+
+---
+
+## Verification
+
+- Touched-module suites (`--rerun-tasks`, `--max-workers=2`): `:rpc-common:test`, `:http-server:test`,
+  `:rpc-server:test`, `:rpc-server:noSdkTest`, `:rpc-client:test`, `:examples:quickstart:test`
+  (incl. `OtelServerSpanQuarkusTest`) — all green.
+- **NS-7 native**: main sources changed (`AbstractHttpHandler`, `LogRedact`, `TraceMeta`). Quickstart
+  native image rebuilt (`quarkusBuild -Dquarkus.native.enabled=true --link-at-build-time
+  --no-fallback` — an unresolved-reflection surface would fail the link) and booted (HTTP :8080
+  `/agent/*` on `AbstractHttpHandler`, gRPC :50051), `/agent/*` return 200 with
+  traceparent/cookie/Authorization, exercising `bindTraceMdc`. New code adds no reflection/resource/
+  proxy surface (`LogRedact`/`TraceMeta` = `String`/`Set`/`Locale`; `MDC` already native-present).
+
+## ADR-0006
+No amendment: pure bug fixes + a logging-hygiene helper. ADR-0003's MDC design and ADR-0006's
+span/coexistence design are unchanged; Fix 1 fills a gap (HTTP face never did the MDC binding the
+gRPC face always did).
+
+## Round 2 — codex r1 responses (R1-1..R1-8)
+
+| Finding | Resolution |
+|---|---|
+| R1-1 query in log | Log `rawPath()` only; `HttpHeaderRedactionTest.queryStringCredentialIsNotLogged`. |
+| R1-2 deny-list bypass | `LogRedact` flipped to allow-list mask-by-default; negative tests for `X-Token`/`X-Goog-Api-Key`. |
+| R1-3 bare cookie leak | `maskCookie` masks bare non-empty segments; leak-locking test replaced by `bareCookieSegmentIsMasked`. |
+| R1-4 malformed W3C forwarded | `TraceMeta.parse` strict; HTTP face binds/forwards only when valid; absent/malformed/duplicate tests. |
+| R1-5 MDC = inbound span | MDC `traceId`/`spanId` overwritten from the active SERVER span's `SpanContext`; captured-MDC test. |
+| R1-6 ghost exclusion overclaimed | Conclusion rewritten: in-process excludes lifecycle **under shared-pipeline only**; A/B export/flush boundary OPEN, gated on staging. Sampler argument qualified to parent-based head sampling. Test relabelled. |
+| R1-7 encoder capture | Test now asserts the full rendered encoder line (`%mdc`+`%msg`) + adversarial variants. |
+| R1-8 async continuation | Documented on `bindTraceMdc` + here; no new API. |
+
+## Round 3 — codex r2 closure responses (R2-1, R2-2)
+
+| Finding | Resolution |
+|---|---|
+| R2-1 parse breaks W3C future versions | `TraceMeta.parse` is now forward-compatible: version `00` = exactly four fields; a higher (non-`ff`) version validates the four common fields and accepts opaque trailing version-specific fields, so the header is forwarded verbatim. Tests: `HttpTraceMdcPropagationTest` version-01 four-field forwarded, version-01+extension forwarded verbatim, version-`ff` rejected, version-`00`+trailing rejected. |
+| R2-2 gRPC face forwards invalid W3C | `ServerContext` now parses BEFORE writing any trace MDC (`traceparent`/`traceId`/`spanId`/`tracestate`/`x-request-id`); invalid → none set → zero outbound. Test: `ServerTraceMdcPropagationTest` (noSdkTest) — malformed gRPC inbound → 0 forwarded; valid + future-version+ext → forwarded verbatim. |
+| advisory (LogRedact "never PII") | Comment softened to "no framework-recognised credentials; values may still carry caller-controlled text (user-agent / x-request-id / tracestate)". |
+
+## Scope honesty
+- Fix 2 ships **no code change** (OPEN at the export/flush boundary; gated on staging repro).
+- Test-scope build edits only (`http-server/build.gradle`: `rpc-client`/`rpc-server`/`grpc-netty` +
+  logback, test scope). No runtime/publish dependency added (NS-3 intact).
+- Main-source change on the gRPC face: `ServerContext` now validates the inbound traceparent before
+  binding trace MDC (R2-2), so the gRPC face no longer forwards a malformed inbound context — the
+  same guarantee as the HTTP face. `TraceMeta.parse` (shared, forward-compatible per R2-1) backs both.

--- a/http-server/build.gradle
+++ b/http-server/build.gradle
@@ -23,6 +23,14 @@ dependencies {
     testRuntimeOnly "org.junit.platform:junit-platform-launcher"
     // OTEL-001: OTel SDK test exporter (test scope only — no SDK in core runtime, NS-3).
     testImplementation "io.opentelemetry:opentelemetry-sdk-testing:${otelVersion}"
+    // OTEL-002 Fix 1: drive a real krpc client + server from an HTTP handler to prove the HTTP
+    // SERVER-span context reaches the outbound gRPC CLIENT call (test scope only — no runtime edge).
+    testImplementation project(':rpc-client')
+    testImplementation project(':rpc-server')
+    testImplementation "io.grpc:grpc-netty:${grpcVersion}"
+    // Real SLF4J provider so ADR-0003 MDC trace propagation + the Fix 3 redaction log-capture are
+    // exercisable (MDC/logging are no-ops under the NOP provider) — mirrors rpc-server's noSdkTest.
+    testImplementation "ch.qos.logback:logback-classic:1.5.18"
 
 }
 

--- a/http-server/src/main/java/tech/krpc/http/server/AbstractHttpHandler.java
+++ b/http-server/src/main/java/tech/krpc/http/server/AbstractHttpHandler.java
@@ -39,9 +39,12 @@ import io.netty.handler.timeout.IdleStateEvent;
 import jakarta.validation.Validator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 import tech.krpc.util.JsonUtils;
 import tech.krpc.util.JsonDecodeException;
 import tech.krpc.context.KrpcOtel;
+import tech.krpc.context.TraceMeta;
+import tech.krpc.util.LogRedact;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.StatusCode;
@@ -114,6 +117,17 @@ public abstract class AbstractHttpHandler extends SimpleChannelInboundHandler<Fu
         var method = request.method().name();
         var uri = request.uri();
 
+        // OTEL-002 Fix 3: inbound-request visibility for webhook/callback debugging, credential-safe
+        // by construction. R1-1: log the raw PATH only — the query string can carry a credential
+        // (e.g. ?access_token=...), so it is never logged. Headers/cookies (incl. the access-token
+        // JWT cookie, Authorization bearer) are routed through LogRedact — value masked, key kept —
+        // so no live token reaches a log line at any level. Consumers cannot patch framework logging,
+        // so redaction lives here (redaction doctrine).
+        if (log.isDebugEnabled()) {
+            log.debug("HTTP inbound {} {} headers={}",
+                    method, new QueryStringDecoder(uri).rawPath(), redactHeaders(request.headers()));
+        }
+
         if ("GET".equals(method)) {
             var query = new QueryStringDecoder(uri);
             var handler = getHanlderMap.get(query.rawPath());
@@ -185,9 +199,24 @@ public abstract class AbstractHttpHandler extends SimpleChannelInboundHandler<Fu
             // B1 (ADR-0006): skip span creation when disabled OR when no OTel SDK is present
             // (no-op TracerProvider) — no extract, no span, no scope. Per-call check (isNoop) so a
             // late-registered SDK still traces; allocation-free on the no-SDK fast path.
+            // OTEL-002 Fix 1 (ADR-0003): bind the inbound W3C trace context into MDC around the
+            // handler body — same as the gRPC face (ServerContext). Independent of OTel span
+            // creation: it makes handler logs carry traceId/spanId AND lets an outbound krpc client
+            // forward the trace via PropagateTraceCall, so a webhook/callback keeps one trace even
+            // with no OTel SDK. Cleared in finally (the VT is per-request, but clear is hygiene).
+            bindTraceMdc(requestHeaders);
             Span span = (OTEL_ENABLED && !KrpcOtel.isNoop())
                     ? startHttpServerSpan(handler, requestHeaders) : null;
             Scope scope = span != null ? span.makeCurrent() : null;
+            // OTEL-002 R1-5: once a real SERVER span is current, logging MDC traceId/spanId must
+            // identify IT, not the inbound caller's span — so a handler error log joins the span
+            // that recorded the error. The inbound traceparent stays in MDC only for the no-SDK
+            // legacy forward (PropagateTraceCall); with an SDK the client injector supersedes it.
+            if (span != null) {
+                var sc = span.getSpanContext();
+                MDC.put(TraceMeta.MDC_TRACE_ID, sc.getTraceId());
+                MDC.put(TraceMeta.MDC_SPAN_ID, sc.getSpanId());
+            }
             try {
                 bytes = handler.handle(dto, extHeaders, requestHeaders);
                 status = extractStatusOverride(extHeaders);
@@ -216,6 +245,7 @@ public abstract class AbstractHttpHandler extends SimpleChannelInboundHandler<Fu
                 if (span != null) {
                     span.end();
                 }
+                MDC.clear();
             }
             final HttpResponseStatus fStatus = status;
             final String fContentType = contentType;
@@ -240,6 +270,58 @@ public abstract class AbstractHttpHandler extends SimpleChannelInboundHandler<Fu
                 .setSpanKind(SpanKind.SERVER)
                 .setParent(parent)
                 .startSpan();
+    }
+
+    // OTEL-002 Fix 1 (ADR-0003): mirror ServerContext's inbound-trace MDC binding for the HTTP
+    // face, exposing the inbound W3C context to the log layout + PropagateTraceCall.
+    //
+    // R1-4: forward ONLY a fully valid W3C traceparent. TraceMeta.parse strictly validates
+    // (hex/version/flags, non-zero ids); a malformed or absent header sets NO trace MDC keys, so the
+    // no-SDK outbound hop carries zero traceparent rather than an incoherent one. The VT starts with
+    // empty MDC, so "not set" == cleared.
+    //
+    // R1-8: this binds MDC + (in the caller) the OTel scope for the SYNCHRONOUS handler body only.
+    // Work a handler schedules onto its own executor / CompletableFuture AFTER handle() returns does
+    // NOT inherit this MDC or the SERVER-span scope — the app must capture/propagate context itself
+    // (e.g. MDC.getCopyOfContextMap / Context.current().wrap). Post-handler async outbound calls are
+    // out of the framework's context scope.
+    private static void bindTraceMdc(HttpHeaders requestHeaders) {
+        var traceparent = requestHeaders.get(TraceMeta.MDC_TRACEPARENT);
+        var ids = TraceMeta.parse(traceparent);
+        if (null == ids) {
+            // Absent or malformed: forward/log nothing. Do not seed MDC with an invalid context.
+            return;
+        }
+        MDC.put(TraceMeta.MDC_TRACEPARENT, traceparent);
+        MDC.put(TraceMeta.MDC_TRACE_ID, ids[0]);
+        MDC.put(TraceMeta.MDC_SPAN_ID, ids[1]);
+        var tracestate = requestHeaders.get(TraceMeta.TRACESTATE);
+        if (null != tracestate) {
+            MDC.put(TraceMeta.TRACESTATE, tracestate);
+        }
+        var requestId = requestHeaders.get(TraceMeta.X_REQUEST_ID);
+        if (null != requestId) {
+            MDC.put(TraceMeta.X_REQUEST_ID, requestId);
+        }
+    }
+
+    // OTEL-002 Fix 3: render inbound headers with credential-bearing values masked (LogRedact),
+    // keeping keys for debuggability. The access-token JWT cookie and Authorization bearer never
+    // appear verbatim in a log line.
+    private static String redactHeaders(HttpHeaders headers) {
+        var sb = new StringBuilder("{");
+        boolean first = true;
+        for (var e : headers) {
+            if (!first) {
+                sb.append(", ");
+            }
+            first = false;
+            // Header names are case-insensitive; render lower-case for a stable, predictable log
+            // (netty preserves the wire case). The value is masked unless allow-listed (LogRedact).
+            var key = e.getKey().toLowerCase(java.util.Locale.ROOT);
+            sb.append(key).append('=').append(LogRedact.value(key, e.getValue()));
+        }
+        return sb.append('}').toString();
     }
 
     /**

--- a/http-server/src/test/java/tech/krpc/http/server/HttpHeaderRedactionTest.java
+++ b/http-server/src/test/java/tech/krpc/http/server/HttpHeaderRedactionTest.java
@@ -1,0 +1,217 @@
+package tech.krpc.http.server;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.net.ServerSocket;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.OutputStreamAppender;
+import io.netty.handler.codec.http.HttpHeaders;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+
+/**
+ * OTEL-002 Fix 3 (field defect #3): the http-server netty face logs inbound requests at DEBUG. A
+ * user JWT rides the {@code access-token} cookie, the {@code Authorization} bearer, an unlisted
+ * custom header, or a query parameter — none may appear verbatim in any log line. Captures the
+ * <b>fully rendered encoder output</b> (R1-7), not just the format string, and exercises the
+ * adversarial bypasses from R1-1/R1-2/R1-3.
+ */
+class HttpHeaderRedactionTest {
+
+    private static final String JWT =
+            "eyJhbGciOiJFUzI1NiJ9.eyJzdWIiOiJ1c2VyLTQyIiwiZXhwIjo5OTk5OTk5OTk5fQ.c2lnLWJ5dGVz";
+
+    private int port;
+    private HttpServer server;
+    private HttpClient client;
+    private Logger handlerLogger;
+    private OutputStreamAppender<ILoggingEvent> appender;
+    private ByteArrayOutputStream rendered;
+    private Level priorLevel;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        handlerLogger = (Logger) LoggerFactory.getLogger(AbstractHttpHandler.class);
+        LoggerContext lc = handlerLogger.getLoggerContext();
+        priorLevel = handlerLogger.getLevel();
+        handlerLogger.setLevel(Level.DEBUG);
+
+        // R1-7: capture the COMPLETE rendered line (level, logger, ALL MDC, message) so a leak via
+        // the layout / MDC / throwable is caught, not only the format string.
+        PatternLayoutEncoder enc = new PatternLayoutEncoder();
+        enc.setContext(lc);
+        enc.setPattern("%-5level %logger{0} mdc=[%mdc] %msg%n");
+        enc.start();
+        rendered = new ByteArrayOutputStream();
+        appender = new OutputStreamAppender<>();
+        appender.setContext(lc);
+        appender.setEncoder(enc);
+        appender.setOutputStream(rendered);
+        appender.start();
+        handlerLogger.addAppender(appender);
+
+        try (ServerSocket ss = new ServerSocket(0)) {
+            port = ss.getLocalPort();
+        }
+        server = new HttpServer(new EchoHandler(), port);
+        server.start();
+        client = HttpClient.newBuilder()
+                .version(HttpClient.Version.HTTP_1_1)
+                .connectTimeout(Duration.ofSeconds(5))
+                .build();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (client != null) client.close();
+        if (server != null) server.shutdown();
+        if (handlerLogger != null && appender != null) {
+            handlerLogger.detachAppender(appender);
+            appender.stop();
+            handlerLogger.setLevel(priorLevel);
+        }
+    }
+
+    @Test
+    void masksJwtCookieAndAuthorization() throws Exception {
+        send("/echo", HttpRequest.newBuilder()
+                .header("Content-Type", "application/json")
+                .header("Authorization", "Bearer " + JWT)
+                .header("Cookie", "access-token=" + JWT + "; theme=dark"));
+
+        String line = awaitRenderedContaining("HTTP inbound");
+        assertNoJwt(line);
+        assertTrue(line.contains("authorization=<redacted>"),
+                () -> "Authorization value must be masked: " + line);
+        assertTrue(line.contains("access-token=<redacted>"),
+                () -> "the access-token cookie value must be masked: " + line);
+        assertTrue(line.contains("theme=<redacted>"),
+                () -> "all cookie values masked (default-deny): " + line);
+        // Allow-listed header preserved for debuggability.
+        assertTrue(line.contains("content-type=application/json"),
+                () -> "diagnostic-safe header kept: " + line);
+    }
+
+    @Test
+    void queryStringCredentialIsNotLogged() throws Exception {
+        // R1-1: a credential in the query string must never be logged; only the raw path is.
+        send("/echo?access_token=" + JWT + "&code=" + JWT, HttpRequest.newBuilder()
+                .header("Content-Type", "application/json"));
+
+        String line = awaitRenderedContaining("HTTP inbound");
+        assertNoJwt(line);
+        assertFalse(line.contains("access_token"), () -> "query key/value must not be logged: " + line);
+        assertTrue(line.contains("/echo"), () -> "the raw path is logged: " + line);
+    }
+
+    @Test
+    void unlistedTokenHeaderIsMasked() throws Exception {
+        // R1-2: a header not on the allow-list is masked, not dumped in cleartext.
+        send("/echo", HttpRequest.newBuilder()
+                .header("Content-Type", "application/json")
+                .header("X-Token", JWT)
+                .header("X-Goog-Api-Key", JWT));
+
+        String line = awaitRenderedContaining("HTTP inbound");
+        assertNoJwt(line);
+        assertTrue(line.contains("x-token=<redacted>"), () -> "unlisted header masked: " + line);
+        assertTrue(line.contains("x-goog-api-key=<redacted>"), () -> "unlisted header masked: " + line);
+    }
+
+    @Test
+    void noRenderedLineContainsTheLiveToken() throws Exception {
+        send("/echo?token=" + JWT, HttpRequest.newBuilder()
+                .header("Authorization", "Bearer " + JWT)
+                .header("Cookie", "access-token=" + JWT)
+                .header("Content-Type", "application/json"));
+        awaitRenderedContaining("HTTP inbound");
+        assertNoJwt(rendered.toString(StandardCharsets.UTF_8));
+    }
+
+    private void assertNoJwt(String text) {
+        assertFalse(text.contains(JWT), () -> "a live JWT leaked into the rendered log: " + text);
+    }
+
+    private void send(String pathAndQuery, HttpRequest.Builder b) throws Exception {
+        HttpResponse<String> r = client.send(
+                b.uri(URI.create("http://127.0.0.1:" + port + pathAndQuery))
+                        .POST(HttpRequest.BodyPublishers.ofString("{}"))
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+        assertEquals(200, r.statusCode(), () -> "request must succeed: " + r.body());
+    }
+
+    private String awaitRenderedContaining(String needle) throws InterruptedException {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+        while (System.nanoTime() < deadline) {
+            String all = rendered.toString(StandardCharsets.UTF_8);
+            for (String line : all.split("\n")) {
+                if (line.contains(needle)) {
+                    return line;
+                }
+            }
+            Thread.sleep(20);
+        }
+        throw new AssertionError("no rendered log line containing '" + needle + "'; captured="
+                + rendered.toString(StandardCharsets.UTF_8));
+    }
+
+    static final class EchoHandler extends AbstractHttpHandler {
+        EchoHandler() {
+            postMap.put("/echo", new PostHandler<String>() {
+                @Override
+                public Class<String> getParamClass() {
+                    return String.class;
+                }
+
+                @Override
+                public String path() {
+                    return "/echo";
+                }
+
+                @Override
+                public boolean useValidator() {
+                    return false;
+                }
+
+                @Override
+                public byte[] handle(String param, List<AsciiHeader> resHeader, HttpHeaders requestHeaders) {
+                    return "{\"ok\":true}".getBytes(StandardCharsets.UTF_8);
+                }
+
+                @Override
+                public String contextType() {
+                    return AbstractHttpHandler.TYPE_JSON;
+                }
+            });
+        }
+
+        @Override
+        public Validator getValidator() {
+            return null;
+        }
+
+        @Override
+        public void initHandler() {
+        }
+    }
+}

--- a/http-server/src/test/java/tech/krpc/http/server/HttpToKrpcClientChainTest.java
+++ b/http-server/src/test/java/tech/krpc/http/server/HttpToKrpcClientChainTest.java
@@ -1,0 +1,264 @@
+package tech.krpc.http.server;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Server;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
+import io.opentelemetry.context.propagation.ContextPropagators;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
+
+import tech.krpc.annotation.RpcService;
+import tech.krpc.client.RpcClientFactory;
+import tech.krpc.context.KrpcOtel;
+import tech.krpc.context.TraceMeta;
+import tech.krpc.model.RpcResult;
+import tech.krpc.server.RpcServerBuilder;
+import tech.krpc.server.ServerContext;
+
+/**
+ * OTEL-002 Fix 1 (field defect #1): an HTTP webhook/callback face receives an inbound W3C
+ * {@code traceparent}, starts a SERVER span, and the handler body makes an outbound krpc gRPC
+ * client call. The outbound CLIENT span (and the downstream SERVER span it reaches) MUST join the
+ * inbound HTTP trace — i.e. the HTTP SERVER-span context must be bound around the handler body so
+ * {@link tech.krpc.client.OtelClientInterceptor} / {@code PropagateTraceCall} inherit it.
+ *
+ * <p>Staging rc1 showed the HTTP face producing a SERVER span while the downstream krpc CLIENT call
+ * opened a <em>new</em> trace (chain broken). This is the red-first reproduction; the gRPC-inbound
+ * analogue ({@code OtelProductionChainTest}) already chains correctly.
+ */
+class HttpToKrpcClientChainTest {
+
+    static final String APP = "otel-http-chain-it";
+
+    @RpcService("Ledger")
+    public interface LedgerService {
+        RpcResult<String> record(String note);
+    }
+
+    public static final class LedgerServiceImpl implements LedgerService {
+        final AtomicInteger inboundTraceparentCount = new AtomicInteger(-1);
+
+        @Override
+        public RpcResult<String> record(String note) {
+            var headers = ServerContext.current().getHeaders();
+            var all = headers.getAll(TraceMeta.TRACEPARENT_KEY);
+            int n = 0;
+            if (all != null) {
+                for (String ignored : all) {
+                    n++;
+                }
+            }
+            inboundTraceparentCount.set(n);
+            return RpcResult.ok("ledgered:" + note);
+        }
+    }
+
+    private InMemorySpanExporter exporter;
+    private SdkTracerProvider tracerProvider;
+    private Server serverB;
+    private ManagedChannel channelB;
+    private ExecutorService execB;
+    private LedgerServiceImpl ledgerImpl;
+    private HttpServer httpServer;
+    private CallbackHandler handler;
+    private int httpPort;
+    private HttpClient client;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        KrpcOtel.install(OpenTelemetry.noop());
+        exporter = InMemorySpanExporter.create();
+        tracerProvider = SdkTracerProvider.builder()
+                .addSpanProcessor(SimpleSpanProcessor.create(exporter))
+                .build();
+        KrpcOtel.install(OpenTelemetrySdk.builder()
+                .setTracerProvider(tracerProvider)
+                .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.getInstance()))
+                .build());
+
+        int portB = freePort();
+        execB = Executors.newVirtualThreadPerTaskExecutor();
+        ledgerImpl = new LedgerServiceImpl();
+        serverB = new RpcServerBuilder.Builder(APP, portB).executor(execB)
+                .addService(ledgerImpl).build().startServer();
+        channelB = ManagedChannelBuilder.forAddress("127.0.0.1", portB).usePlaintext().build();
+        LedgerService ledgerClient = new RpcClientFactory(APP, channelB).get(LedgerService.class);
+
+        httpPort = freePort();
+        handler = new CallbackHandler(ledgerClient);
+        httpServer = new HttpServer(handler, httpPort);
+        httpServer.start();
+        client = HttpClient.newBuilder()
+                .version(HttpClient.Version.HTTP_1_1)
+                .connectTimeout(Duration.ofSeconds(5))
+                .build();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (client != null) client.close();
+        if (httpServer != null) httpServer.shutdown();
+        if (channelB != null) channelB.shutdownNow();
+        if (serverB != null) serverB.shutdownNow();
+        if (execB != null) execB.shutdownNow();
+        if (tracerProvider != null) tracerProvider.shutdown();
+        KrpcOtel.install(OpenTelemetry.noop());
+    }
+
+    @Test
+    void httpInboundContextReachesOutboundKrpcClient() throws Exception {
+        String traceId = "0af7651916cd43dd8448eb211c80319c";
+        String parentSpanId = "b7ad6b7169203331";
+        String traceparent = "00-" + traceId + "-" + parentSpanId + "-01";
+
+        HttpResponse<String> r = client.send(
+                HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + httpPort + "/callback"))
+                        .header("Content-Type", "application/json")
+                        .header("traceparent", traceparent)
+                        .POST(HttpRequest.BodyPublishers.ofString("{}"))
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+        assertEquals(200, r.statusCode(), () -> "callback must succeed: " + r.body());
+
+        SpanData httpServerSpan = awaitSpan(SpanKind.SERVER, "/callback");
+        SpanData clientRecord = awaitSpan(SpanKind.CLIENT, "/record");
+        SpanData serverRecord = awaitSpan(SpanKind.SERVER, "/record");
+
+        assertEquals(traceId, httpServerSpan.getTraceId(), "HTTP SERVER span must join the inbound trace");
+        assertEquals(traceId, clientRecord.getTraceId(),
+                "outbound CLIENT call must stay in the HTTP inbound trace (field defect: it started a NEW trace)");
+        assertEquals(traceId, serverRecord.getTraceId(),
+                "downstream SERVER must stay in the inbound trace across the hop");
+
+        assertEquals(httpServerSpan.getSpanId(), clientRecord.getParentSpanId(),
+                "the outbound CLIENT span must be a child of the HTTP SERVER span (context bound around handler)");
+        assertEquals(clientRecord.getSpanId(), serverRecord.getParentSpanId(),
+                "downstream SERVER must be a child of the outbound CLIENT span");
+
+        assertEquals(1, ledgerImpl.inboundTraceparentCount.get(),
+                "exactly one traceparent must reach the downstream on the wire");
+    }
+
+    @Test
+    void capturedHandlerMdcIdentifiesTheHttpServerSpan() throws Exception {
+        // R1-5: with an SDK, logging MDC (traceId/spanId) inside the handler must identify the HTTP
+        // SERVER span itself — not the inbound caller's parent span — so handler logs join that span.
+        String traceId = "0af7651916cd43dd8448eb211c80319c";
+        String parentSpanId = "b7ad6b7169203331";
+        HttpResponse<String> r = client.send(
+                HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + httpPort + "/callback"))
+                        .header("Content-Type", "application/json")
+                        .header("traceparent", "00-" + traceId + "-" + parentSpanId + "-01")
+                        .POST(HttpRequest.BodyPublishers.ofString("{}"))
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+        assertEquals(200, r.statusCode(), () -> "callback must succeed: " + r.body());
+
+        SpanData httpServerSpan = awaitSpan(SpanKind.SERVER, "/callback");
+        assertEquals(httpServerSpan.getTraceId(), handler.mdcTraceId.get(),
+                "MDC traceId must equal the exported HTTP SERVER span's traceId");
+        assertEquals(httpServerSpan.getSpanId(), handler.mdcSpanId.get(),
+                "MDC spanId must equal the SERVER span's own id, not the inbound parent " + parentSpanId);
+        assertEquals(parentSpanId, httpServerSpan.getParentSpanId(),
+                "sanity: the SERVER span is a child of the inbound parent");
+    }
+
+    private SpanData awaitSpan(SpanKind kind, String nameSuffix) throws InterruptedException {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+        while (System.nanoTime() < deadline) {
+            for (SpanData s : exporter.getFinishedSpanItems()) {
+                if (s.getKind() == kind && s.getName().endsWith(nameSuffix)) {
+                    return s;
+                }
+            }
+            Thread.sleep(25);
+        }
+        throw new AssertionError("no " + kind + " span ending '" + nameSuffix + "' in "
+                + exporter.getFinishedSpanItems());
+    }
+
+    private static int freePort() throws IOException {
+        try (ServerSocket ss = new ServerSocket(0)) {
+            return ss.getLocalPort();
+        }
+    }
+
+    /** HTTP handler whose body performs an outbound krpc client call, like a webhook callback. */
+    static final class CallbackHandler extends AbstractHttpHandler {
+        private final LedgerService ledger;
+        final AtomicReference<String> mdcTraceId = new AtomicReference<>();
+        final AtomicReference<String> mdcSpanId = new AtomicReference<>();
+
+        CallbackHandler(LedgerService ledger) {
+            this.ledger = ledger;
+            postMap.put("/callback", new PostHandler<String>() {
+                @Override
+                public Class<String> getParamClass() {
+                    return String.class;
+                }
+
+                @Override
+                public String path() {
+                    return "/callback";
+                }
+
+                @Override
+                public boolean useValidator() {
+                    return false;
+                }
+
+                @Override
+                public byte[] handle(String param, List<AsciiHeader> resHeader, HttpHeaders requestHeaders) {
+                    // R1-5: capture the logging MDC visible inside the handler body.
+                    mdcTraceId.set(MDC.get(TraceMeta.MDC_TRACE_ID));
+                    mdcSpanId.set(MDC.get(TraceMeta.MDC_SPAN_ID));
+                    RpcResult<String> res = ledger.record("from-http");
+                    return ("{\"ok\":\"" + res.getData() + "\"}").getBytes(StandardCharsets.UTF_8);
+                }
+
+                @Override
+                public String contextType() {
+                    return AbstractHttpHandler.TYPE_JSON;
+                }
+            });
+        }
+
+        @Override
+        public Validator getValidator() {
+            return null;
+        }
+
+        @Override
+        public void initHandler() {
+        }
+    }
+}

--- a/http-server/src/test/java/tech/krpc/http/server/HttpTraceMdcPropagationTest.java
+++ b/http-server/src/test/java/tech/krpc/http/server/HttpTraceMdcPropagationTest.java
@@ -1,0 +1,247 @@
+package tech.krpc.http.server;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Server;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.opentelemetry.api.OpenTelemetry;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import tech.krpc.annotation.RpcService;
+import tech.krpc.client.RpcClientFactory;
+import tech.krpc.context.KrpcOtel;
+import tech.krpc.context.TraceMeta;
+import tech.krpc.model.RpcResult;
+import tech.krpc.server.RpcServerBuilder;
+import tech.krpc.server.ServerContext;
+
+/**
+ * OTEL-002 Fix 1 (field defect #1), ADR-0003 path with <b>no OTel SDK installed</b>: the HTTP
+ * webhook/callback face must forward the inbound W3C {@code traceparent} to an outbound krpc client
+ * call exactly like the gRPC face does (via MDC + {@code PropagateTraceCall}). On staging rc1 the
+ * HTTP handler never bound the inbound trace into the handler body, so the downstream call carried
+ * no {@code traceparent} and started a new trace. This reproduces that break deterministically
+ * without any SDK: propagation must not depend on span creation.
+ */
+class HttpTraceMdcPropagationTest {
+
+    static final String APP = "otel-http-mdc-it";
+
+    @RpcService("Ledger")
+    public interface LedgerService {
+        RpcResult<String> record(String note);
+    }
+
+    public static final class LedgerServiceImpl implements LedgerService {
+        final AtomicInteger inboundTraceparentCount = new AtomicInteger(-1);
+        final AtomicReference<String> inboundTraceparent = new AtomicReference<>();
+
+        @Override
+        public RpcResult<String> record(String note) {
+            var headers = ServerContext.current().getHeaders();
+            var all = headers.getAll(TraceMeta.TRACEPARENT_KEY);
+            int n = 0;
+            String last = null;
+            if (all != null) {
+                for (String v : all) {
+                    n++;
+                    last = v;
+                }
+            }
+            inboundTraceparentCount.set(n);
+            inboundTraceparent.set(last);
+            return RpcResult.ok("ledgered:" + note);
+        }
+    }
+
+    private Server serverB;
+    private ManagedChannel channelB;
+    private ExecutorService execB;
+    private LedgerServiceImpl ledgerImpl;
+    private HttpServer httpServer;
+    private int httpPort;
+    private HttpClient client;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        // No SDK: span creation is a no-op, so trace continuity depends solely on ADR-0003 MDC
+        // forwarding — the same mechanism the gRPC face uses.
+        KrpcOtel.install(OpenTelemetry.noop());
+
+        int portB = freePort();
+        execB = Executors.newVirtualThreadPerTaskExecutor();
+        ledgerImpl = new LedgerServiceImpl();
+        serverB = new RpcServerBuilder.Builder(APP, portB).executor(execB)
+                .addService(ledgerImpl).build().startServer();
+        channelB = ManagedChannelBuilder.forAddress("127.0.0.1", portB).usePlaintext().build();
+        LedgerService ledgerClient = new RpcClientFactory(APP, channelB).get(LedgerService.class);
+
+        httpPort = freePort();
+        httpServer = new HttpServer(new CallbackHandler(ledgerClient), httpPort);
+        httpServer.start();
+        client = HttpClient.newBuilder()
+                .version(HttpClient.Version.HTTP_1_1)
+                .connectTimeout(Duration.ofSeconds(5))
+                .build();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (client != null) client.close();
+        if (httpServer != null) httpServer.shutdown();
+        if (channelB != null) channelB.shutdownNow();
+        if (serverB != null) serverB.shutdownNow();
+        if (execB != null) execB.shutdownNow();
+        KrpcOtel.install(OpenTelemetry.noop());
+    }
+
+    @Test
+    void validInboundTraceparent_forwardedExactlyOnce() throws Exception {
+        String tp = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01";
+        post(b -> b.header("traceparent", tp));
+        assertEquals(1, ledgerImpl.inboundTraceparentCount.get(),
+                "valid inbound traceparent forwarded exactly once");
+        assertEquals(tp, ledgerImpl.inboundTraceparent.get(),
+                "downstream receives the same traceparent verbatim (ADR-0003)");
+    }
+
+    @Test
+    void absentInboundTraceparent_zeroOutbound() throws Exception {
+        post(b -> b);
+        assertEquals(0, ledgerImpl.inboundTraceparentCount.get(),
+                "no inbound traceparent -> nothing forwarded (no-SDK, no span creation)");
+    }
+
+    @Test
+    void malformedInboundTraceparent_zeroOutbound() throws Exception {
+        // R1-4: non-hex trace id + all-zero span id + non-hex flags -> strictly rejected, never sent.
+        post(b -> b.header("traceparent", "00-zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz-0000000000000000-xx"));
+        assertEquals(0, ledgerImpl.inboundTraceparentCount.get(),
+                "malformed inbound traceparent must not be forwarded (zero outbound)");
+    }
+
+    @Test
+    void duplicateInboundTraceparent_exactlyOneOutbound() throws Exception {
+        String tp1 = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01";
+        String tp2 = "00-11111111111111111111111111111111-2222222222222222-01";
+        post(b -> b.header("traceparent", tp1).header("traceparent", tp2));
+        assertEquals(1, ledgerImpl.inboundTraceparentCount.get(),
+                "a duplicate traceparent header must still yield exactly one outbound value");
+    }
+
+    @Test
+    void futureVersionFourField_forwardedVerbatim() throws Exception {
+        // R2-1: a valid future (non-ff) version with four fields is accepted and forwarded verbatim.
+        String tp = "01-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01";
+        post(b -> b.header("traceparent", tp));
+        assertEquals(1, ledgerImpl.inboundTraceparentCount.get());
+        assertEquals(tp, ledgerImpl.inboundTraceparent.get(), "version-01 forwarded verbatim");
+    }
+
+    @Test
+    void futureVersionWithExtension_forwardedVerbatim() throws Exception {
+        // R2-1: a higher version MAY carry opaque trailing fields — accept + forward the whole
+        // header unchanged (no continuity loss on the no-SDK path).
+        String tp = "01-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01-cafebabe";
+        post(b -> b.header("traceparent", tp));
+        assertEquals(1, ledgerImpl.inboundTraceparentCount.get());
+        assertEquals(tp, ledgerImpl.inboundTraceparent.get(),
+                "future-version extension forwarded verbatim, opaque trailing kept");
+    }
+
+    @Test
+    void versionFf_rejected_zeroOutbound() throws Exception {
+        // R2-1: version ff is reserved/invalid — never forwarded.
+        post(b -> b.header("traceparent",
+                "ff-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"));
+        assertEquals(0, ledgerImpl.inboundTraceparentCount.get(), "version ff must be rejected");
+    }
+
+    @Test
+    void version00WithTrailingField_rejected() throws Exception {
+        // R2-1: version 00 is exactly four fields — a trailing segment is invalid.
+        post(b -> b.header("traceparent",
+                "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01-extra"));
+        assertEquals(0, ledgerImpl.inboundTraceparentCount.get(),
+                "version 00 with a trailing field must be rejected");
+    }
+
+    private void post(java.util.function.UnaryOperator<HttpRequest.Builder> headers) throws Exception {
+        var b = HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + httpPort + "/callback"))
+                .header("Content-Type", "application/json");
+        HttpResponse<String> r = client.send(
+                headers.apply(b).POST(HttpRequest.BodyPublishers.ofString("{}")).build(),
+                HttpResponse.BodyHandlers.ofString());
+        assertEquals(200, r.statusCode(), () -> "callback must succeed: " + r.body());
+    }
+
+    private static int freePort() throws IOException {
+        try (ServerSocket ss = new ServerSocket(0)) {
+            return ss.getLocalPort();
+        }
+    }
+
+    /** HTTP handler whose body performs an outbound krpc client call, like a webhook callback. */
+    static final class CallbackHandler extends AbstractHttpHandler {
+        private final LedgerService ledger;
+
+        CallbackHandler(LedgerService ledger) {
+            this.ledger = ledger;
+            postMap.put("/callback", new PostHandler<String>() {
+                @Override
+                public Class<String> getParamClass() {
+                    return String.class;
+                }
+
+                @Override
+                public String path() {
+                    return "/callback";
+                }
+
+                @Override
+                public boolean useValidator() {
+                    return false;
+                }
+
+                @Override
+                public byte[] handle(String param, List<AsciiHeader> resHeader, HttpHeaders requestHeaders) {
+                    RpcResult<String> res = ledger.record("from-http");
+                    return ("{\"ok\":\"" + res.getData() + "\"}").getBytes(StandardCharsets.UTF_8);
+                }
+
+                @Override
+                public String contextType() {
+                    return AbstractHttpHandler.TYPE_JSON;
+                }
+            });
+        }
+
+        @Override
+        public Validator getValidator() {
+            return null;
+        }
+
+        @Override
+        public void initHandler() {
+        }
+    }
+}

--- a/rpc-common/src/main/java/tech/krpc/context/TraceMeta.java
+++ b/rpc-common/src/main/java/tech/krpc/context/TraceMeta.java
@@ -32,18 +32,54 @@ public interface TraceMeta {
     Key<String> TRACESTATE_KEY  = Metadata.Key.of(TRACESTATE, Metadata.ASCII_STRING_MARSHALLER);
 
     /**
-     * ADR-0003: parse a W3C traceparent header.
-     * Format: {@code version-traceid(32hex)-spanid(16hex)-flags(2hex)}.
-     * Returns {@code [traceId, spanId]}, or null when the input is null or malformed.
+     * ADR-0003 / OTEL-002 R1-4 + R2-1: parse and validate a W3C traceparent header.
+     * Format: {@code version(2hex)-traceid(32hex)-spanid(16hex)-flags(2hex)}, all lower-case hex.
+     * Returns {@code [traceId, spanId]} only when the four common fields are valid: correct
+     * lengths, lower-case hex throughout, version not {@code ff} (reserved), and neither the
+     * trace-id nor span-id all-zero (both forbidden). Version {@code 00} must be exactly four
+     * fields; a higher (non-{@code ff}) version MAY carry opaque trailing version-specific fields,
+     * which are accepted and left to the caller to forward verbatim (W3C forward-compatibility).
+     * Any malformed common field → null, so a caller never forwards/logs an incoherent context.
      */
     static String[] parse(String traceparent) {
         if (null == traceparent) {
             return null;
         }
         var parts = traceparent.split("-", -1);
-        if (parts.length != 4 || parts[1].length() != 32 || parts[2].length() != 16 || parts[3].length() != 2) {
+        // Four common W3C fields are mandatory for every version; a future (non-ff) version MAY add
+        // opaque trailing fields after them (R2-1 forward-compat) — validate the four, keep the rest.
+        if (parts.length < 4
+                || parts[0].length() != 2 || !isLowerHex(parts[0]) || "ff".equals(parts[0])
+                || parts[1].length() != 32 || !isLowerHex(parts[1]) || isAllZero(parts[1])
+                || parts[2].length() != 16 || !isLowerHex(parts[2]) || isAllZero(parts[2])
+                || parts[3].length() != 2 || !isLowerHex(parts[3])) {
+            return null;
+        }
+        // Version 00 is exactly four fields — any trailing segment makes it invalid. Higher versions
+        // tolerate a trailing version-specific portion (treated as opaque; the header is forwarded
+        // verbatim by the caller).
+        if ("00".equals(parts[0]) && parts.length != 4) {
             return null;
         }
         return new String[]{parts[1], parts[2]};
+    }
+
+    private static boolean isLowerHex(String s) {
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            if ((c < '0' || c > '9') && (c < 'a' || c > 'f')) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean isAllZero(String s) {
+        for (int i = 0; i < s.length(); i++) {
+            if (s.charAt(i) != '0') {
+                return false;
+            }
+        }
+        return true;
     }
 }

--- a/rpc-common/src/main/java/tech/krpc/util/LogRedact.java
+++ b/rpc-common/src/main/java/tech/krpc/util/LogRedact.java
@@ -1,0 +1,117 @@
+package tech.krpc.util;
+
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * OTEL-002 Fix 3: credential-safe rendering of request metadata for logs. Framework code that emits
+ * inbound headers / cookies / gRPC metadata MUST route values through here so a user JWT (the
+ * {@code access-token} cookie), an {@code Authorization} bearer token, or any deployment-specific
+ * auth header never lands in a log line — not even at DEBUG, not even in staging (redaction
+ * doctrine).
+ *
+ * <p><b>Mask by default (R1-4 review).</b> A deny-list cannot make a full arbitrary-header dump
+ * safe: the next unlisted token-bearing header ({@code X-Token}, {@code X-Goog-Api-Key}, a custom
+ * auth header) would leak. So every header value is masked UNLESS its name is on the explicit
+ * {@link #DIAGNOSTIC_SAFE} allow-list of headers whose values are non-sensitive and useful for
+ * debugging. {@code Cookie}/{@code Set-Cookie} are handled specially: cookie names are kept but
+ * every value is masked (a bare, {@code =}-less segment is masked whole — it may itself be a
+ * secret). The mask is a fixed sentinel — never a prefix/suffix of the live secret.
+ *
+ * <p>Transport-agnostic on purpose: it works on header <em>name</em> + <em>value</em> strings, so
+ * both the netty HTTP face ({@code HttpHeaders}) and the gRPC face ({@code io.grpc.Metadata}) share
+ * one policy instead of re-deriving a sensitive-key list per call site.
+ */
+public final class LogRedact {
+
+    private LogRedact() {}
+
+    /** Replacement for a masked value. Fixed sentinel — never reveals any part of the secret. */
+    public static final String MASK = "<redacted>";
+
+    /**
+     * Header names (lower-case) whose values are safe and useful to log verbatim. Everything else
+     * is masked. Kept deliberately small: transport/negotiation/observability metadata only — no
+     * header on it carries a framework-recognised credential. (Values may still contain
+     * caller-controlled text — a custom user-agent, x-request-id, or tracestate — so this is a
+     * "no known secret" list, not a "no PII" guarantee.)
+     */
+    public static final Set<String> DIAGNOSTIC_SAFE = Set.of(
+            // content negotiation / framing
+            "content-type",
+            "content-length",
+            "content-encoding",
+            "accept",
+            "accept-encoding",
+            "accept-language",
+            "accept-charset",
+            // transport / client identification (non-secret)
+            "user-agent",
+            "host",
+            "connection",
+            "date",
+            "cache-control",
+            // W3C trace context + correlation (non-secret; needed to debug propagation)
+            "traceparent",
+            "tracestate",
+            "x-request-id",
+            // krpc / MCP protocol metadata (non-secret)
+            "mcp-protocol-version",
+            "c-id",
+            "x-krpc-http-status");
+
+    /** True when a header's value is on the diagnostic-safe allow-list and may be logged verbatim. */
+    public static boolean isDiagnosticSafe(String headerName) {
+        return headerName != null && DIAGNOSTIC_SAFE.contains(headerName.toLowerCase(Locale.ROOT));
+    }
+
+    /**
+     * Log-safe value for a single header. Allow-listed → returned unchanged. {@code cookie}/
+     * {@code set-cookie} → each cookie name kept, every value (and any bare segment) masked.
+     * Everything else → masked (default-deny).
+     */
+    public static String value(String headerName, String value) {
+        if (value == null) {
+            return null;
+        }
+        String lower = headerName == null ? "" : headerName.toLowerCase(Locale.ROOT);
+        if ("cookie".equals(lower) || "set-cookie".equals(lower)) {
+            return maskCookie(value);
+        }
+        return DIAGNOSTIC_SAFE.contains(lower) ? value : MASK;
+    }
+
+    /**
+     * Masks every cookie value while keeping cookie names, e.g.
+     * {@code "access-token=eyJ...; theme=dark"} → {@code "access-token=<redacted>; theme=<redacted>"}.
+     * A bare ({@code =}-less) non-empty segment is masked whole — it is ambiguous whether it is a
+     * flag or a secret, so default-deny applies and nothing verbatim survives.
+     */
+    public static String maskCookie(String cookieHeader) {
+        if (cookieHeader == null || cookieHeader.isEmpty()) {
+            return cookieHeader;
+        }
+        StringBuilder sb = new StringBuilder(cookieHeader.length());
+        String[] cookies = cookieHeader.split(";", -1);
+        for (int i = 0; i < cookies.length; i++) {
+            if (i > 0) {
+                sb.append(';');
+            }
+            String cookie = cookies[i];
+            int lead = 0;
+            while (lead < cookie.length() && cookie.charAt(lead) == ' ') {
+                lead++;
+            }
+            sb.append(cookie, 0, lead);
+            String body = cookie.substring(lead);
+            int eq = body.indexOf('=');
+            if (eq < 0) {
+                // Bare segment: empty stays empty; any non-empty value is masked whole (could be a secret).
+                sb.append(body.isEmpty() ? "" : MASK);
+            } else {
+                sb.append(body, 0, eq + 1).append(MASK);
+            }
+        }
+        return sb.toString();
+    }
+}

--- a/rpc-common/src/test/java/tech/krpc/util/LogRedactTest.java
+++ b/rpc-common/src/test/java/tech/krpc/util/LogRedactTest.java
@@ -1,0 +1,91 @@
+package tech.krpc.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * OTEL-002 Fix 3: the shared credential redactor. Policy is MASK-BY-DEFAULT (R1-2): every header
+ * value is masked unless its name is on the diagnostic-safe allow-list; {@code cookie} keeps names
+ * but masks all values including bare segments (R1-3).
+ */
+class LogRedactTest {
+
+    private static final String JWT =
+            "eyJhbGciOiJFUzI1NiJ9.eyJzdWIiOiJ1c2VyLTQyIn0.c2lnbmF0dXJlLWJ5dGVz";
+
+    // --- default-deny: anything not allow-listed is masked -----------------------------------
+
+    @Test
+    void authorizationBearerIsMasked() {
+        String out = LogRedact.value("Authorization", "Bearer " + JWT);
+        assertEquals(LogRedact.MASK, out);
+        assertFalse(out.contains(JWT));
+    }
+
+    @Test
+    void unlistedTokenShapedHeadersAreMasked() {
+        // R1-2 negative probes: names not on the allow-list must be masked, not passed through.
+        for (String name : new String[]{"X-Token", "X-Access-Token", "X-Goog-Api-Key",
+                "X-Api-Key", "X-Auth-Token", "Proxy-Authorization", "X-Some-Vendor-Secret"}) {
+            String out = LogRedact.value(name, JWT);
+            assertEquals(LogRedact.MASK, out, () -> name + " must be masked by default");
+            assertFalse(out.contains(JWT));
+        }
+    }
+
+    // --- allow-list: diagnostic-safe headers pass through ------------------------------------
+
+    @Test
+    void diagnosticSafeHeadersPassThrough() {
+        assertEquals("application/json", LogRedact.value("Content-Type", "application/json"));
+        assertEquals("curl/8.0", LogRedact.value("User-Agent", "curl/8.0"));
+        assertEquals("00-abc-def-01", LogRedact.value("traceparent", "00-abc-def-01"));
+        assertEquals("req-123", LogRedact.value("X-Request-Id", "req-123"));
+        assertTrue(LogRedact.isDiagnosticSafe("HOST"));
+        assertFalse(LogRedact.isDiagnosticSafe("authorization"));
+        assertFalse(LogRedact.isDiagnosticSafe("x-token"));
+    }
+
+    // --- cookie: names kept, all values masked (R1-3) ----------------------------------------
+
+    @Test
+    void cookieKeepsNamesMasksValues_includingAccessToken() {
+        String out = LogRedact.value("Cookie", "access-token=" + JWT + "; theme=dark");
+        assertEquals("access-token=" + LogRedact.MASK + "; theme=" + LogRedact.MASK, out);
+        assertFalse(out.contains(JWT), "the access-token JWT must not survive");
+        assertTrue(out.contains("access-token="), "cookie names are kept for debuggability");
+    }
+
+    @Test
+    void bareCookieSegmentIsMasked() {
+        // R1-3: a bare (=-less) JWT-shaped segment could itself be the secret — mask it whole.
+        String out = LogRedact.value("cookie", JWT + "; theme=dark");
+        assertFalse(out.contains(JWT), () -> "bare secret segment leaked: " + out);
+        assertEquals(LogRedact.MASK + "; theme=" + LogRedact.MASK, out);
+    }
+
+    @Test
+    void bareCookieSegmentTrailing_isMasked() {
+        String out = LogRedact.value("cookie", "access-token=" + JWT + "; " + JWT);
+        assertFalse(out.contains(JWT), () -> "trailing bare secret leaked: " + out);
+        assertEquals("access-token=" + LogRedact.MASK + "; " + LogRedact.MASK, out);
+    }
+
+    // --- edges --------------------------------------------------------------------------------
+
+    @Test
+    void caseInsensitiveMatching() {
+        assertEquals(LogRedact.MASK, LogRedact.value("AUTHORIZATION", "Bearer x"));
+        assertEquals("text/plain", LogRedact.value("CONTENT-TYPE", "text/plain"));
+        assertTrue(LogRedact.maskCookie("Access-Token=" + JWT).startsWith("Access-Token="));
+        assertFalse(LogRedact.value("COOKIE", "access-token=" + JWT).contains(JWT));
+    }
+
+    @Test
+    void nullValueStaysNull() {
+        assertEquals(null, LogRedact.value("Authorization", null));
+    }
+}

--- a/rpc-server/src/main/java/tech/krpc/server/ServerContext.java
+++ b/rpc-server/src/main/java/tech/krpc/server/ServerContext.java
@@ -93,15 +93,17 @@ public class ServerContext extends AbstractContext<ServerResult, InputProto, Ser
         super(service, method, resDto, arg, lastChain);
         this.headers = headers;
         injectMdc(headers, HttpConst.CLIENT_ID_HEADER,CLIENT_ID);
-        // ADR-0003: parse inbound W3C traceparent, expose traceId/spanId to the log layout.
+        // ADR-0003 / OTEL-002 R2-2: validate the inbound W3C traceparent BEFORE writing any
+        // trace-related MDC. An invalid header sets none of MDC_TRACEPARENT / traceId / spanId /
+        // tracestate / x-request-id, so the no-SDK client path forwards zero traceparent downstream
+        // rather than an incoherent one — matching the HTTP face. A valid future-version header
+        // (with opaque trailing fields) is bound and forwarded verbatim.
         var traceparent = headers.get(TraceMeta.TRACEPARENT_KEY);
-        if(null != traceparent){
+        var ids = TraceMeta.parse(traceparent);
+        if(null != ids){
             MDC.put(TraceMeta.MDC_TRACEPARENT, traceparent);
-            var ids = TraceMeta.parse(traceparent);
-            if(null != ids){
-                MDC.put(TraceMeta.MDC_TRACE_ID, ids[0]);
-                MDC.put(TraceMeta.MDC_SPAN_ID, ids[1]);
-            }
+            MDC.put(TraceMeta.MDC_TRACE_ID, ids[0]);
+            MDC.put(TraceMeta.MDC_SPAN_ID, ids[1]);
             injectMdc(headers, TraceMeta.TRACESTATE,TraceMeta.TRACESTATE_KEY);
             injectMdc(headers, TraceMeta.X_REQUEST_ID,TraceMeta.REQUEST_ID);
         }

--- a/rpc-server/src/noSdkTest/java/tech/krpc/server/ServerTraceMdcPropagationTest.java
+++ b/rpc-server/src/noSdkTest/java/tech/krpc/server/ServerTraceMdcPropagationTest.java
@@ -1,0 +1,166 @@
+package tech.krpc.server;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Server;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
+
+import tech.krpc.annotation.RpcService;
+import tech.krpc.client.RpcClientFactory;
+import tech.krpc.context.KrpcOtel;
+import tech.krpc.context.TraceMeta;
+import tech.krpc.model.RpcResult;
+
+/**
+ * OTEL-002 R2-2 (no OTel SDK): the gRPC face ({@code ServerContext}) must validate the inbound W3C
+ * traceparent BEFORE writing any trace MDC, so a malformed inbound context is NOT forwarded on the
+ * outbound krpc hop (only derived log IDs were suppressed before). Runs on the SDK-free classpath so
+ * propagation is pure ADR-0003 MDC forwarding ({@code PropagateTraceCall}), not OTel injection.
+ *
+ * <p>Topology: the test seeds its own MDC (simulating an inbound caller), calls Order-service A over
+ * the wire; A's handler calls Ledger-service B. B records the traceparent it actually received. A's
+ * {@code ServerContext} is the face under test.
+ */
+class ServerTraceMdcPropagationTest {
+
+    static final String APP = "otel-grpc-mdc-it";
+
+    @RpcService("Ledger")
+    public interface LedgerService {
+        RpcResult<String> record(String note);
+    }
+
+    @RpcService("Order")
+    public interface OrderService {
+        RpcResult<String> place(String note);
+    }
+
+    public static final class LedgerServiceImpl implements LedgerService {
+        final AtomicInteger count = new AtomicInteger(-1);
+        final AtomicReference<String> value = new AtomicReference<>();
+
+        @Override
+        public RpcResult<String> record(String note) {
+            var all = ServerContext.current().getHeaders().getAll(TraceMeta.TRACEPARENT_KEY);
+            int n = 0;
+            String last = null;
+            if (all != null) {
+                for (String v : all) {
+                    n++;
+                    last = v;
+                }
+            }
+            count.set(n);
+            value.set(last);
+            return RpcResult.ok("ledgered:" + note);
+        }
+    }
+
+    public static final class OrderServiceImpl implements OrderService {
+        private final LedgerService ledger;
+
+        OrderServiceImpl(LedgerService ledger) {
+            this.ledger = ledger;
+        }
+
+        @Override
+        public RpcResult<String> place(String note) {
+            return RpcResult.ok("ordered:" + ledger.record(note).getData());
+        }
+    }
+
+    private Server serverA;
+    private Server serverB;
+    private ManagedChannel channelA;
+    private ManagedChannel channelB;
+    private ExecutorService execA;
+    private ExecutorService execB;
+    private LedgerServiceImpl ledgerImpl;
+    private OrderService orderClient;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        KrpcOtel.install(io.opentelemetry.api.OpenTelemetry.noop());
+
+        int portB = freePort();
+        execB = Executors.newVirtualThreadPerTaskExecutor();
+        ledgerImpl = new LedgerServiceImpl();
+        serverB = new RpcServerBuilder.Builder(APP, portB).executor(execB)
+                .addService(ledgerImpl).build().startServer();
+        channelB = ManagedChannelBuilder.forAddress("127.0.0.1", portB).usePlaintext().build();
+        LedgerService ledgerClient = new RpcClientFactory(APP, channelB).get(LedgerService.class);
+
+        int portA = freePort();
+        execA = Executors.newVirtualThreadPerTaskExecutor();
+        serverA = new RpcServerBuilder.Builder(APP, portA).executor(execA)
+                .addService(new OrderServiceImpl(ledgerClient)).build().startServer();
+        channelA = ManagedChannelBuilder.forAddress("127.0.0.1", portA).usePlaintext().build();
+        orderClient = new RpcClientFactory(APP, channelA).get(OrderService.class);
+    }
+
+    @AfterEach
+    void tearDown() {
+        MDC.clear();
+        if (channelA != null) channelA.shutdownNow();
+        if (channelB != null) channelB.shutdownNow();
+        if (serverA != null) serverA.shutdownNow();
+        if (serverB != null) serverB.shutdownNow();
+        if (execA != null) execA.shutdownNow();
+        if (execB != null) execB.shutdownNow();
+        KrpcOtel.install(io.opentelemetry.api.OpenTelemetry.noop());
+    }
+
+    /** Seed the caller MDC, drive A over the wire, and report what B received. */
+    private void placeWithInbound(String inboundTraceparent) {
+        MDC.put(TraceMeta.MDC_TRACEPARENT, inboundTraceparent);
+        try {
+            assertTrue(orderClient.place("x").isOk());
+        } finally {
+            MDC.clear();
+        }
+    }
+
+    @Test
+    void validInbound_forwardedVerbatim() {
+        String tp = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01";
+        placeWithInbound(tp);
+        assertEquals(1, ledgerImpl.count.get());
+        assertEquals(tp, ledgerImpl.value.get());
+    }
+
+    @Test
+    void malformedInbound_zeroForwarded() {
+        // R2-2: A receives a malformed traceparent; ServerContext must NOT bind it, so A->B carries none.
+        placeWithInbound("00-zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz-0000000000000000-xx");
+        assertEquals(0, ledgerImpl.count.get(),
+                "malformed gRPC inbound traceparent must not be forwarded downstream");
+    }
+
+    @Test
+    void futureVersionWithExtension_forwardedVerbatim() {
+        // R2-1 + R2-2: a valid higher version with an opaque trailing field is bound and forwarded whole.
+        String tp = "01-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01-cafebabe";
+        placeWithInbound(tp);
+        assertEquals(1, ledgerImpl.count.get());
+        assertEquals(tp, ledgerImpl.value.get(), "future-version traceparent forwarded verbatim");
+    }
+
+    private static int freePort() throws IOException {
+        try (ServerSocket ss = new ServerSocket(0)) {
+            return ss.getLocalPort();
+        }
+    }
+}

--- a/rpc-server/src/test/java/tech/krpc/server/GhostClientSpanTest.java
+++ b/rpc-server/src/test/java/tech/krpc/server/GhostClientSpanTest.java
@@ -1,0 +1,241 @@
+package tech.krpc.server;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Server;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
+import io.opentelemetry.context.propagation.ContextPropagators;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
+
+import tech.krpc.annotation.RpcService;
+import tech.krpc.client.AsyncClient;
+import tech.krpc.client.AsyncMethod;
+import tech.krpc.client.RpcClientFactory;
+import tech.krpc.context.KrpcOtel;
+import tech.krpc.model.RpcResult;
+
+/**
+ * OTEL-002 Fix 2 (field defect #2), REGRESSION GUARD — not a field-defect exclusion (R1-6).
+ *
+ * <p>The field ghost: a downstream SERVER span references a CLIENT span-id as parent, but no CLIENT
+ * span body reaches the backend; traceId continuity intact. This test proves only that, under a
+ * <b>single shared</b> {@code BatchSpanProcessor} + parent-based sampler + a successful
+ * {@code forceFlush}, krpc's client span lifecycle exports the CLIENT body with correct parentage
+ * for both the sync ({@code blockingUnaryCall}) and async ({@code asyncUnaryCall}) paths — i.e. it
+ * excludes an in-process span-lifecycle bug.
+ *
+ * <p>It deliberately does NOT reproduce the field's independent A/B boundary: service A and B share
+ * one {@code OpenTelemetrySdk}/exporter here and the flush always succeeds, so it cannot exercise A
+ * exporting its CLIENT span through a separate OTLP pipeline, an A-side queue drop, or A pod
+ * termination before its batch drains. Those remain OPEN and are gated on the consumer's staging
+ * repro (see OTEL-002_IMPL_omp.md, Fix 2). The sampler-flag exclusion argument holds only under
+ * parent-based head sampling on the downstream.
+ */
+class GhostClientSpanTest {
+
+    static final String APP = "otel-ghost-it";
+
+    @RpcService("Ledger")
+    public interface LedgerService {
+        RpcResult<String> record(String note);
+    }
+
+    @RpcService("Order")
+    public interface OrderService {
+        RpcResult<String> place(String note);
+        RpcResult<String> placeAsync(String note);
+    }
+
+    public static final class LedgerServiceImpl implements LedgerService {
+        @Override
+        public RpcResult<String> record(String note) {
+            return RpcResult.ok("ledgered:" + note);
+        }
+    }
+
+    public static final class OrderServiceImpl implements OrderService {
+        private final LedgerService ledger;
+        private final AsyncClient<LedgerService> asyncLedger;
+        final CountDownLatch asyncDone = new CountDownLatch(1);
+
+        OrderServiceImpl(LedgerService ledger) {
+            this.ledger = ledger;
+            this.asyncLedger = new AsyncClient<>(ledger);
+        }
+
+        @Override
+        public RpcResult<String> place(String note) {
+            var res = ledger.record(note);
+            return RpcResult.ok("ordered:" + res.getData());
+        }
+
+        @Override
+        public RpcResult<String> placeAsync(String note) {
+            asyncLedger.call("record", note, new AsyncMethod.ResultObserver<String>() {
+                @Override
+                public void onError(Throwable t) {
+                    asyncDone.countDown();
+                }
+
+                @Override
+                public void onSuccess(RpcResult<String> res) {
+                    asyncDone.countDown();
+                }
+
+                @Override
+                public void onCompleted() {
+                }
+            });
+            return RpcResult.ok("ordered-async");
+        }
+    }
+
+    private InMemorySpanExporter exporter;
+    private SdkTracerProvider tracerProvider;
+    private OpenTelemetrySdk sdk;
+    private Server serverA;
+    private Server serverB;
+    private ManagedChannel channelA;
+    private ManagedChannel channelB;
+    private ExecutorService execA;
+    private ExecutorService execB;
+    private OrderService orderClient;
+    private OrderServiceImpl orderImpl;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        KrpcOtel.install(OpenTelemetry.noop());
+        exporter = InMemorySpanExporter.create();
+        tracerProvider = SdkTracerProvider.builder()
+                // Staging pipeline: async batch processor (NOT SimpleSpanProcessor) + parent-based
+                // sampler. Short delay so the background flush is exercised without a long wait.
+                .addSpanProcessor(BatchSpanProcessor.builder(exporter)
+                        .setScheduleDelay(50, TimeUnit.MILLISECONDS)
+                        .build())
+                .setSampler(Sampler.parentBased(Sampler.alwaysOn()))
+                .build();
+        sdk = OpenTelemetrySdk.builder()
+                .setTracerProvider(tracerProvider)
+                .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.getInstance()))
+                .build();
+        KrpcOtel.install(sdk);
+
+        int portB = freePort();
+        execB = Executors.newVirtualThreadPerTaskExecutor();
+        serverB = new RpcServerBuilder.Builder(APP, portB).executor(execB)
+                .addService(new LedgerServiceImpl()).build().startServer();
+        channelB = ManagedChannelBuilder.forAddress("127.0.0.1", portB).usePlaintext().build();
+        LedgerService ledgerClient = new RpcClientFactory(APP, channelB).get(LedgerService.class);
+
+        int portA = freePort();
+        execA = Executors.newVirtualThreadPerTaskExecutor();
+        orderImpl = new OrderServiceImpl(ledgerClient);
+        serverA = new RpcServerBuilder.Builder(APP, portA).executor(execA)
+                .addService(orderImpl).build().startServer();
+        channelA = ManagedChannelBuilder.forAddress("127.0.0.1", portA).usePlaintext().build();
+        orderClient = new RpcClientFactory(APP, channelA).get(OrderService.class);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (channelA != null) channelA.shutdownNow();
+        if (channelB != null) channelB.shutdownNow();
+        if (serverA != null) serverA.shutdownNow();
+        if (serverB != null) serverB.shutdownNow();
+        if (execA != null) execA.shutdownNow();
+        if (execB != null) execB.shutdownNow();
+        if (tracerProvider != null) tracerProvider.shutdown();
+        KrpcOtel.install(OpenTelemetry.noop());
+    }
+
+    @Test
+    void syncChain_clientSpanBodyIsExported() throws Exception {
+        Span root = sdk.getTracer("test").spanBuilder("inbound").setSpanKind(SpanKind.SERVER).startSpan();
+        try (Scope s = root.makeCurrent()) {
+            assertTrue(orderClient.place("x").isOk());
+        } finally {
+            root.end();
+        }
+        tracerProvider.forceFlush().join(10, TimeUnit.SECONDS);
+
+        SpanData serverB = awaitSpan(SpanKind.SERVER, "/record");
+        assertClientParentExported(serverB);
+    }
+
+    @Test
+    void asyncChain_clientSpanBodyIsExported() throws Exception {
+        Span root = sdk.getTracer("test").spanBuilder("inbound").setSpanKind(SpanKind.SERVER).startSpan();
+        try (Scope s = root.makeCurrent()) {
+            assertTrue(orderClient.placeAsync("y").isOk());
+        } finally {
+            root.end();
+        }
+        assertTrue(orderImpl.asyncDone.await(10, TimeUnit.SECONDS), "async ledger call must complete");
+        tracerProvider.forceFlush().join(10, TimeUnit.SECONDS);
+
+        SpanData serverB = awaitSpan(SpanKind.SERVER, "/record");
+        assertClientParentExported(serverB);
+    }
+
+    /** The core ghost check: SERVER-B's parent must be a CLIENT span whose body was exported. */
+    private void assertClientParentExported(SpanData serverB) {
+        String parentId = serverB.getParentSpanId();
+        SpanData clientParent = null;
+        for (SpanData s : exporter.getFinishedSpanItems()) {
+            if (s.getSpanId().equals(parentId)) {
+                clientParent = s;
+                break;
+            }
+        }
+        assertNotNull(clientParent, () -> "GHOST: SERVER-B parent CLIENT span " + parentId
+                + " was never exported. Exported: " + exporter.getFinishedSpanItems());
+        assertEquals(SpanKind.CLIENT, clientParent.getKind(),
+                "SERVER-B's parent must be the outbound CLIENT span");
+        assertEquals(serverB.getTraceId(), clientParent.getTraceId(), "same trace");
+    }
+
+    private SpanData awaitSpan(SpanKind kind, String nameSuffix) throws InterruptedException {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+        while (System.nanoTime() < deadline) {
+            for (SpanData s : exporter.getFinishedSpanItems()) {
+                if (s.getKind() == kind && s.getName().endsWith(nameSuffix)) {
+                    return s;
+                }
+            }
+            Thread.sleep(25);
+        }
+        throw new AssertionError("no " + kind + " span ending '" + nameSuffix + "' in "
+                + exporter.getFinishedSpanItems());
+    }
+
+    private static int freePort() throws IOException {
+        try (ServerSocket ss = new ServerSocket(0)) {
+            return ss.getLocalPort();
+        }
+    }
+}


### PR DESCRIPTION
## OTEL-002 — field-found defects from staging rc1 (rc→GA gate)

- **Fix 1 — HTTP→outbound chain break**: real root cause differed from the field's guess — the OTel SERVER span WAS current across the handler body (OTEL-001); the HTTP face simply never bound inbound W3C context into MDC the way the gRPC face does, so `PropagateTraceCall` forwarded nothing. Fixed via `AbstractHttpHandler.bindTraceMdc(...)` + MDC from the active SERVER span's `SpanContext`. Red-first: `HttpTraceMdcPropagationTest` red on dev → green.
- **Fix 2 — ghost CLIENT spans: NOT reproduced, no speculative fix** (先量再改). `GhostClientSpanTest` rebuilds the staging pipeline (BatchSpanProcessor + parentBased sampler, sync + async client paths) — CLIENT spans export with correct parentage. The independent A/B export/flush boundary (pod termination before batch drain, OTLP queue drop) remains OPEN and is gated on consumer staging verification (acceptance: CLIENT span body appears). Test kept as regression guard.
- **Fix 3 — sensitive-header redaction**: shared `tech.krpc.util.LogRedact`, **mask-by-default with an explicit diagnostic-safe allow-list** (deny-lists can't make full header dumps safe); bare cookie segments masked; URIs logged path-only (no query). Netty DEBUG header logging goes through it.
- **Hardening from review**: `TraceMeta.parse` strict for version 00 AND W3C forward-compatible (non-ff higher versions keep opaque trailing fields, forwarded verbatim); gRPC face (`ServerContext`) validates BEFORE any trace MDC write — malformed inbound propagates nothing on either face.

## Verification
- Full touched suites + `:rpc-server:noSdkTest` + quickstart `@QuarkusTest` green (`--rerun-tasks`); NS-4 zero wire change; NS-7 quickstart native image rebuilt (`--link-at-build-time --no-fallback`) and booted, `/agent/*` exercised with traceparent/cookie/Authorization.
- Adversarial review: codex, 3 rounds, 10 blocking findings total, all closed with independent re-verification (r3 APPROVE).

Follow-up (not in this PR): ghost-span staging verification via consumer window; on merge, cut `1.1.1-rc2` for the consumer three-point acceptance (chain stitched / CLIENT span body / no ghost parents) = GA signal.