### PR TITLE
test(arch): scan-face completeness guard + NS-1/NS-4/NS-6 gates (ARCH-TEST-V2)

### DIFF
--- a/arch-test/build.gradle
+++ b/arch-test/build.gradle
@@ -16,12 +16,65 @@ dependencies {
     testImplementation project(':http-server')
 
     testImplementation "com.tngtech.archunit:archunit-junit5:1.4.1"
-    // Plain JUnit 5 for the OnlyCoreModules scope-substitution guard test (ARCH-001 NB1).
+    // Plain JUnit 5 for the OnlyCoreModules scope-substitution guard test (ARCH-001 NB1)
+    // and the ARCH-002 scan-face / NS-1 completeness gates.
     testImplementation "org.junit.jupiter:junit-jupiter:5.11.4"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher"
 }
 
+// ARCH-002: emit Gradle's AUTHORITATIVE evaluated project model so the scan-face
+// (ScanFaceCompletenessTest) and NS-1 (NoProtoInProductionSourceTest) gates observe the
+// REAL included projects — every include form (single/double quote, parenthesized,
+// multiline), intermediate projects (e.g. :examples), custom projectDir, and each java
+// project's main source dirs — instead of a hand-rolled settings.gradle text parser that
+// silently ignores unsupported syntax. Two files under build/arch-inventory/:
+//   projects.tsv     : <projectPath>\t<projectDir>\t<mainSrcDir:mainSrcDir:...>  (one per subproject)
+//   scanned-deps.txt : this module's testImplementation project(...) paths (the scan face)
+def archInventoryDir = layout.buildDirectory.dir('arch-inventory')
+
+// Captured at THIS module's configuration time (declared deps are available immediately).
+def scannedDepPaths = configurations.testImplementation.dependencies
+    .findAll { it instanceof ProjectDependency }
+    .collect { it.path }
+    .join('\n')
+
+// Captured after ALL projects are evaluated, so sourceSets (java plugin) are populated.
+def projectRows = []
+gradle.projectsEvaluated {
+    rootProject.allprojects.findAll { it != rootProject }.sort { it.path }.each { p ->
+        def srcDirs = p.plugins.hasPlugin('java')
+            ? p.sourceSets.main.allSource.srcDirs.collect { it.absolutePath }
+            : [p.file('src').absolutePath]
+        projectRows << [p.path, p.projectDir.absolutePath, srcDirs.join(File.pathSeparator)].join('\t')
+    }
+}
+
+def writeArchInventory = tasks.register('writeArchInventory') {
+    def projectsFile = archInventoryDir.map { it.file('projects.tsv') }
+    def depsFile = archInventoryDir.map { it.file('scanned-deps.txt') }
+    outputs.files(projectsFile, depsFile)
+    // ALWAYS regenerate: the evaluated project model (project set, projectDirs, source
+    // roots, arch-test's project deps) is recomputed every configuration; a normal build
+    // must never reuse a stale inventory. The task is trivial (writes two small files, a
+    // few ms), so always-out-of-date is the simplest fully-staleness-proof choice — cheaper
+    // than trying to enumerate every model input dimension and risk missing one.
+    outputs.upToDateWhen { false }
+    doLast {
+        def pf = projectsFile.get().asFile
+        pf.parentFile.mkdirs()
+        pf.text = projectRows.join('\n') + '\n'
+        depsFile.get().asFile.text = scannedDepPaths + '\n'
+    }
+}
+
 test {
+    // Declaring the (always-regenerated) inventory files as INPUTS means test re-runs
+    // whenever their CONTENT changes — i.e. whenever the project model changes — even on a
+    // plain `:arch-test:test` with no --rerun-tasks. (Also wires the task dependency.) So a
+    // new/renamed/removed module can never pass against a stale scan-face snapshot.
+    inputs.files(writeArchInventory)
+    // The gates read Gradle's authoritative project model from here.
+    systemProperty 'arch.inventory.dir', archInventoryDir.get().asFile.absolutePath
     useJUnitPlatform()
     // arch-test always discovers @ArchTest rules; keep the Gradle 9 guard honest.
     failOnNoDiscoveredTests = true

--- a/arch-test/src/test/java/tech/krpc/arch/BuildInventory.java
+++ b/arch-test/src/test/java/tech/krpc/arch/BuildInventory.java
@@ -1,0 +1,105 @@
+package tech.krpc.arch;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeSet;
+
+/**
+ * ARCH-002 — reads Gradle's AUTHORITATIVE evaluated project model, emitted by the
+ * {@code writeArchInventory} task (see arch-test/build.gradle) into
+ * {@code build/arch-inventory/}. Using Gradle's own model (not a hand-rolled
+ * {@code settings.gradle} text parser) means the scan-face and NS-1 gates observe every
+ * included project regardless of {@code include} syntax (single/double quote,
+ * parenthesized, multiline), including intermediate projects and custom {@code projectDir}.
+ */
+final class BuildInventory {
+
+    private BuildInventory() {}
+
+    /** One included subproject: Gradle path, real dir, and main (production) source dirs. */
+    static final class Module {
+        /** Gradle path with the leading colon stripped, e.g. {@code rpc-api}, {@code examples:quickstart}. */
+        final String name;
+        final Path projectDir;
+        final List<Path> mainSrcDirs;
+
+        Module(String name, Path projectDir, List<Path> mainSrcDirs) {
+            this.name = name;
+            this.projectDir = projectDir;
+            this.mainSrcDirs = mainSrcDirs;
+        }
+    }
+
+    private static Path inventoryDir() {
+        String dir = System.getProperty("arch.inventory.dir");
+        assertTrue(dir != null && !dir.isBlank(),
+            "arch.inventory.dir system property is unset — the writeArchInventory task must run"
+            + " before this test (see arch-test/build.gradle test { dependsOn writeArchInventory }).");
+        Path p = Paths.get(dir);
+        assertTrue(Files.isDirectory(p), "arch inventory dir does not exist: " + p);
+        return p;
+    }
+
+    /** Name (colon-stripped Gradle path) -> module, in build order. */
+    static Map<String, Module> modules() {
+        Path file = inventoryDir().resolve("projects.tsv");
+        assertTrue(Files.isRegularFile(file), "inventory projects.tsv missing: " + file);
+        Map<String, Module> out = new LinkedHashMap<>();
+        try {
+            for (String line : Files.readAllLines(file, StandardCharsets.UTF_8)) {
+                if (line.isBlank()) {
+                    continue;
+                }
+                String[] cols = line.split("\t", -1);
+                assertTrue(cols.length >= 2, "malformed inventory row: " + line);
+                String name = stripLeadingColon(cols[0]);
+                Path projectDir = Paths.get(cols[1]);
+                List<Path> srcDirs = new ArrayList<>();
+                if (cols.length >= 3 && !cols[2].isBlank()) {
+                    for (String s : cols[2].split(java.io.File.pathSeparator)) {
+                        if (!s.isBlank()) {
+                            srcDirs.add(Paths.get(s));
+                        }
+                    }
+                }
+                out.put(name, new Module(name, projectDir, srcDirs));
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        assertTrue(out.containsKey("rpc-api"),
+            "sanity: Gradle project inventory must contain the core modules: " + out.keySet());
+        return out;
+    }
+
+    /** arch-test's testImplementation project(...) paths (the scan face), colon-stripped. */
+    static java.util.Set<String> scannedDeps() {
+        Path file = inventoryDir().resolve("scanned-deps.txt");
+        assertTrue(Files.isRegularFile(file), "inventory scanned-deps.txt missing: " + file);
+        java.util.Set<String> out = new TreeSet<>();
+        try {
+            for (String line : Files.readAllLines(file, StandardCharsets.UTF_8)) {
+                if (!line.isBlank()) {
+                    out.add(stripLeadingColon(line.trim()));
+                }
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        return out;
+    }
+
+    private static String stripLeadingColon(String path) {
+        return path.startsWith(":") ? path.substring(1) : path;
+    }
+}

--- a/arch-test/src/test/java/tech/krpc/arch/NoProtoInProductionSourceTest.java
+++ b/arch-test/src/test/java/tech/krpc/arch/NoProtoInProductionSourceTest.java
@@ -1,0 +1,103 @@
+package tech.krpc.arch;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+/**
+ * NS-1 gate — the interface IS the contract; service authors write NO {@code .proto} files.
+ *
+ * <p>The umbrella NORTH_STAR NS-1 says KRPC is interface-first: a service is a Java
+ * interface + DTOs, and "service authors write no proto files" (SPEC §"Interface-first").
+ * This gate makes that structural: NO {@code *.proto} may live under any PRODUCTION
+ * module's source. A hand-authored proto there turns the build RED.
+ *
+ * <p>Module dirs come from Gradle's evaluated project model (see {@link BuildInventory}), not
+ * a {@code settings.gradle} text parser or a {@code repoRoot/<name>/src} convention guess —
+ * so a module declared with any include form or a custom {@code projectDir} is still scanned
+ * at its real location. For each production module the scan covers the UNION of (a) the whole
+ * {@code <projectDir>/src} tree — which catches a hand-authored {@code src/main/proto/x.proto}
+ * even though no protobuf plugin registers {@code proto/} as a source dir — and (b) every
+ * registered main source-set directory reported by Gradle (which catches a source root placed
+ * OUTSIDE {@code src}). Production modules = every included project except non-production ones
+ * ({@code test-*}, {@code examples*}, and the {@code arch-test} gate).
+ *
+ * <p>Real state (verified): the sole wire-envelope proto ({@code InputProto}/
+ * {@code OutputProto}/{@code SerialEnum}) lives at repo-top-level {@code proto/internal.proto},
+ * NOT under any module's source; the generated Java is checked in under {@code rpc-common}. So
+ * the production scan is empty and {@link #ALLOWLIST} is empty. Should a wire-envelope proto
+ * ever be moved INTO a module source tree, add its exact repo-relative path to the allowlist
+ * with a comment.
+ *
+ * <p>Plain JUnit test, not an {@link com.tngtech.archunit.lang.ArchRule}: the fact under
+ * test is source files on disk, which a bytecode analyzer cannot see. No frozen store entry.
+ */
+class NoProtoInProductionSourceTest {
+
+    private final Path repoRoot = ArchitectureTest.OnlyCoreModules.repoRoot();
+
+    /**
+     * Repo-relative paths of {@code .proto} files explicitly permitted under a production
+     * module source (e.g. a framework wire-envelope proto), each justified by a comment.
+     * EMPTY today: the only envelope proto lives at top-level {@code proto/}, outside src.
+     */
+    private static final Set<String> ALLOWLIST = new TreeSet<>(List.of());
+
+    /** A production (runtime / runtime-adjacent) module: not a test fixture, example, or the gate. */
+    private static boolean isProduction(String name) {
+        return !name.startsWith("test-") && !name.startsWith("examples") && !name.equals("arch-test");
+    }
+
+    @Test
+    void noProtoFilesUnderAnyProductionModuleSource() throws IOException {
+        Map<String, BuildInventory.Module> inventory = BuildInventory.modules();
+        Set<String> offenders = new TreeSet<>();
+        int scannedModules = 0;
+        for (BuildInventory.Module m : inventory.values()) {
+            if (!isProduction(m.name)) {
+                continue;
+            }
+            scannedModules++;
+            assertTrue(Files.isDirectory(m.projectDir),
+                "production module " + m.name + " has a non-existent projectDir (Gradle project"
+                + " model incomplete?): " + m.projectDir);
+
+            // Union of the whole src tree and each registered main source-set root. offenders is
+            // a Set, so overlapping roots never double-count.
+            Set<Path> roots = new LinkedHashSet<>();
+            roots.add(m.projectDir.resolve("src"));
+            roots.addAll(m.mainSrcDirs);
+            for (Path root : roots) {
+                if (!Files.isDirectory(root)) {
+                    continue; // module with no such source root
+                }
+                try (Stream<Path> walk = Files.walk(root)) {
+                    walk.filter(Files::isRegularFile)
+                        .filter(p -> p.getFileName().toString().endsWith(".proto"))
+                        .forEach(p -> {
+                            String rel = repoRoot.relativize(p).toString().replace('\\', '/');
+                            if (!ALLOWLIST.contains(rel)) {
+                                offenders.add(rel);
+                            }
+                        });
+                }
+            }
+        }
+        assertTrue(scannedModules >= 6,
+            "sanity: expected to scan at least the six core production modules, saw " + scannedModules);
+        assertTrue(offenders.isEmpty(),
+            "NS-1 violated: .proto file(s) authored under production module source — KRPC is"
+            + " interface-first (Java interface + DTOs, no proto authoring). Offenders: "
+            + offenders + ". If a file is a legitimate framework wire-envelope proto, add its"
+            + " repo-relative path to NoProtoInProductionSourceTest.ALLOWLIST with a reason.");
+    }
+}

--- a/arch-test/src/test/java/tech/krpc/arch/ScanFaceCompletenessTest.java
+++ b/arch-test/src/test/java/tech/krpc/arch/ScanFaceCompletenessTest.java
@@ -1,0 +1,158 @@
+package tech.krpc.arch;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+/**
+ * ARCH-002 — scan-face completeness guard (anti "hardcoded scan-face silent miss").
+ *
+ * <p>{@link ArchitectureTest.OnlyCoreModules#MODULES} and arch-test's
+ * {@code testImplementation project(...)} list are a HARDCODED scan face: a new core
+ * module added to the build but not to arch-test would be silently UNSCANNED — its classes
+ * never enter the ArchUnit analysis, so R1..R4 pass vacuously for it (a false green). This
+ * is the "hardcoded scan-face silent miss" class the NORTH_STAR doctrine forbids.
+ *
+ * <p>The authoritative module set comes from Gradle's EVALUATED PROJECT MODEL (emitted by
+ * the {@code writeArchInventory} task; see {@link BuildInventory}), NOT a hand-rolled
+ * {@code settings.gradle} text parser. A text parser silently ignores unsupported syntax
+ * ({@code include "x"}, {@code include('x')}, multiline) and would let a module escape;
+ * reading Gradle's own model means every included project is seen regardless of include
+ * form, including intermediate projects (e.g. {@code :examples}) and custom {@code projectDir}.
+ * This test then forces EVERY included module to be consciously classified as SCANNED or
+ * EXCLUDED; a new one that is neither turns RED naming it (mirrors R2's completeness guard).
+ *
+ * <p>Plain JUnit test, not an {@link com.tngtech.archunit.lang.ArchRule}: the fact under
+ * test is the build's project graph, not bytecode. No frozen store entry; ratchet untouched.
+ */
+class ScanFaceCompletenessTest {
+
+    private final Path repoRoot = ArchitectureTest.OnlyCoreModules.repoRoot();
+
+    // The scan face: the modules ArchUnit actually analyzes (ADR-0005 "six core modules").
+    private static final Set<String> SCANNED =
+        new TreeSet<>(Arrays.asList(ArchitectureTest.OnlyCoreModules.MODULES));
+
+    /**
+     * Modules deliberately OUTSIDE the ArchUnit core scan, each with a reviewed reason.
+     * ADDING to this set is the conscious escape hatch (mirrors R2's layer assignment):
+     * a new module must be classified here OR added to the scan face, never left dangling.
+     *
+     * <ul>
+     *   <li>{@code test-api}, {@code test-jwks}, {@code test-server-spring},
+     *       {@code test-server} — test-only fixture / demo modules ({@code test-*}); their
+     *       {@code src/test} are {@code main()}-based demos, not the production contract graph.</li>
+     *   <li>{@code rpc-client-spring}, {@code rpc-server-spring} — Spring Boot autoconfig
+     *       ADAPTER modules ({@code tech.krpc.{client,server}.spring}). ADR-0005 scopes the
+     *       gate to the six transport/runtime core modules; DI-framework integration glue is
+     *       consumer-facing surface, not the core contract graph. (Policy-review trigger: if a
+     *       Spring adapter grows runtime behavior, revisit adapter ownership — see ADR-0005
+     *       ARCH-002 addendum. This guard forces that decision rather than silent drift.)</li>
+     *   <li>{@code ext-rpc-gen} — build-time codegen tool ({@code tech.krpc.ext.gen}); it emits
+     *       client stubs, it is not part of the runtime contract graph (ADR-0005 exclusion).</li>
+     *   <li>{@code arch-test} — the gate module itself; it owns no production classes.</li>
+     *   <li>{@code examples} — the examples aggregator project (parent of examples:quickstart;
+     *       Gradle materializes it as an intermediate project); unpublished, no production classes.</li>
+     *   <li>{@code examples:quickstart} — unpublished example, not production.</li>
+     * </ul>
+     */
+    private static final Set<String> EXCLUDED = new TreeSet<>(Arrays.asList(
+        "test-api", "test-jwks", "test-server-spring", "test-server",
+        "rpc-client-spring", "rpc-server-spring",
+        "ext-rpc-gen",
+        "arch-test",
+        "examples", "examples:quickstart"));
+
+    @Test
+    void everyIncludedModuleIsConsciouslyClassified() {
+        Map<String, BuildInventory.Module> inventory = BuildInventory.modules();
+        Set<String> includes = new TreeSet<>(inventory.keySet());
+
+        // Every included project dir Gradle reported must actually exist on disk (honesty:
+        // the inventory names real projects, never a phantom the walk would treat as empty).
+        for (BuildInventory.Module m : inventory.values()) {
+            assertTrue(Files.isDirectory(m.projectDir),
+                "included project " + m.name + " has a non-existent projectDir: " + m.projectDir);
+        }
+
+        // 1) THE ARCH-002 CATCH: a project Gradle includes that is neither scanned nor
+        //    explicitly excluded is an unclassified silent miss -> RED, naming it.
+        Set<String> unclassified = new TreeSet<>(includes);
+        unclassified.removeAll(SCANNED);
+        unclassified.removeAll(EXCLUDED);
+        assertTrue(unclassified.isEmpty(),
+            "Gradle includes project(s) not classified by arch-test: " + unclassified
+            + " — a new core module must be ADDED to ArchitectureTest.OnlyCoreModules.MODULES"
+            + " (and arch-test/build.gradle testImplementation) so ArchUnit scans it,"
+            + " OR added to ScanFaceCompletenessTest.EXCLUDED with a documented reason."
+            + " Leaving it unclassified would let R1..R4 pass vacuously for it (false green).");
+
+        // 2) The scan face may not name a module the build does not include (no phantom).
+        Set<String> scannedNotIncluded = new TreeSet<>(SCANNED);
+        scannedNotIncluded.removeAll(includes);
+        assertTrue(scannedNotIncluded.isEmpty(),
+            "OnlyCoreModules.MODULES names module(s) absent from the build: " + scannedNotIncluded);
+
+        // 3) The exclusion list may not carry a stale entry (keeps the allowlist honest).
+        Set<String> excludedNotIncluded = new TreeSet<>(EXCLUDED);
+        excludedNotIncluded.removeAll(includes);
+        assertTrue(excludedNotIncluded.isEmpty(),
+            "ScanFaceCompletenessTest.EXCLUDED has stale entries absent from the build: "
+            + excludedNotIncluded);
+
+        // 4) A module cannot be both scanned and excluded.
+        Set<String> both = new TreeSet<>(SCANNED);
+        both.retainAll(EXCLUDED);
+        assertTrue(both.isEmpty(), "module(s) both scanned and excluded: " + both);
+    }
+
+    @Test
+    void scanFaceModuleListMatchesClasspathDeps() {
+        // Internal consistency of the scan face: OnlyCoreModules.MODULES must equal arch-test's
+        // testImplementation project(...) set (from Gradle's own dependency model). A scanned
+        // module missing from the classpath imports 0 classes (false green); a classpath module
+        // missing from MODULES is scanned but unpinned.
+        Set<String> deps = BuildInventory.scannedDeps();
+        assertEquals(new LinkedHashSet<>(SCANNED), new LinkedHashSet<>(deps),
+            "OnlyCoreModules.MODULES and arch-test/build.gradle testImplementation project(...) "
+            + "must be identical. MODULES=" + SCANNED + " testImplementation=" + deps);
+    }
+
+    @Test
+    void everyOnDiskModuleDirectoryIsClassified() throws IOException {
+        // Independent filesystem corroboration (does NOT read the Gradle inventory): every
+        // first-level directory that carries a build.gradle is a real module on disk and MUST
+        // be classified. Catches a module dir added on disk (a would-be include) before it can
+        // slip in unscanned. Nested modules (e.g. examples/quickstart) are covered via their
+        // Gradle path in everyIncludedModuleIsConsciouslyClassified. A dir that carries its OWN
+        // settings.gradle is a nested STANDALONE build (e.g. benchmark — "a separate build"),
+        // not a subproject of this build, so it is skipped.
+        Set<String> classified = new TreeSet<>(SCANNED);
+        classified.addAll(EXCLUDED);
+        Set<String> offenders = new TreeSet<>();
+        try (Stream<Path> top = Files.list(repoRoot)) {
+            top.filter(Files::isDirectory)
+                .filter(d -> Files.isRegularFile(d.resolve("build.gradle")))
+                .filter(d -> !Files.isRegularFile(d.resolve("settings.gradle")))
+                .forEach(d -> {
+                    String name = d.getFileName().toString();
+                    if (!classified.contains(name)) {
+                        offenders.add(name);
+                    }
+                });
+        }
+        assertTrue(offenders.isEmpty(),
+            "on-disk module directory(ies) with a build.gradle not classified by arch-test: "
+            + offenders + " — add to OnlyCoreModules.MODULES (scan) or EXCLUDED (with a reason).");
+    }
+}

--- a/docs/decisions/ADR-0005-architecture-gates.md
+++ b/docs/decisions/ADR-0005-architecture-gates.md
@@ -216,3 +216,110 @@ NB5 (r6): the anchors must be plain directories — `requireNotSymlinked` reject
 symlinked module dir or `build/` (intra-repo redirection); a scratch-temp-dir probe
 (`modx/build -> ../mody/build`) proves the guard trips and a plain dir passes.
 All six `ScopeGuardTest` cases green; frozen store md5 unchanged across every round.
+
+## ARCH-002 addendum — scan-face completeness guard + NS-1/NS-4/NS-6 gates
+
+Status: accepted. Date: 2026-07-17 (r1 review incorporated). Extends the decision above;
+no existing rule or store entry changes.
+
+### The silent-miss weakness this closes
+
+The v1 analysis subject is a HARDCODED scan face: the six-module list in
+`OnlyCoreModules.MODULES` and the matching `testImplementation project(':...')` deps in
+`arch-test/build.gradle`. A new core module added to the build but not to BOTH places would
+be silently UNSCANNED — its classes never enter the ArchUnit import, so R1..R4 pass
+vacuously for it (a false green). This is the "hardcoded scan-face silent miss" class the
+fitness-test doctrine guards against by comparing the build's real project set against the
+scanned set.
+
+### Mechanism (`ScanFaceCompletenessTest`, plain test)
+
+The authoritative module set is Gradle's **evaluated project model**, emitted by the
+`writeArchInventory` task (`arch-test/build.gradle`) into `build/arch-inventory/` and read
+by `BuildInventory`. Using Gradle's own model — not a hand-rolled `settings.gradle` text
+parser — means every included project is seen regardless of `include` syntax
+(`include 'x'`, `include "x"`, `include('x')`, multiline), including intermediate projects
+(Gradle materializes `:examples` as the parent of `:examples:quickstart`) and custom
+`projectDir`. (A prior text parser matched only single-quoted tokens on `include`-prefixed
+lines and silently dropped the other forms — the r1 review's blocking finding #1.)
+
+The inventory is staleness-proof on a NORMAL run (no `--rerun-tasks`): `writeArchInventory`
+is `outputs.upToDateWhen { false }` (always regenerates the model — a few ms), and `test`
+declares the inventory files as inputs, so a model change (added/renamed/removed module,
+source-root or dependency edit) changes the file content and re-runs the test. A prior
+version declared outputs but no inputs, so Gradle skipped it as up-to-date and a stale
+snapshot could pass a plain `:arch-test:test` — the r2 review's blocking finding.
+
+The test forces EVERY included project to be consciously classified as **SCANNED**
+(`OnlyCoreModules.MODULES`) or **EXCLUDED** (a documented allowlist, each entry justified);
+a project that is neither turns RED naming it — mechanically identical to R2's completeness
+guard. A second assertion pins `OnlyCoreModules.MODULES` == arch-test's `testImplementation
+project(...)` set (also from Gradle's dependency model), so a scanned module can never be
+missing from the analysis classpath (importing zero classes = vacuous green). A third,
+filesystem-independent assertion walks the repo's first-level directories and requires every
+`build.gradle`-bearing dir to be classified — a nested STANDALONE build (its own
+`settings.gradle`, e.g. `benchmark`) is skipped as not-a-subproject.
+
+The EXCLUDED allowlist and its reasons (honest derivation): `test-*` (test fixture/demo
+modules), `examples` + `examples:quickstart` (unpublished example aggregator + module),
+`arch-test` (the gate itself, owns no production classes), `ext-rpc-gen` (build-time codegen
+tool, not the runtime contract graph), and `rpc-client-spring` / `rpc-server-spring` (Spring
+Boot autoconfig ADAPTER modules — this ADR scopes the gate to the six transport/runtime core
+modules; DI-framework integration glue is consumer-facing surface, not the core contract
+graph). **Policy-review trigger (r1 advisory #5):** the Spring adapters currently hold only
+autoconfig glue; before non-trivial runtime behavior is added to any adapter, revisit adapter
+runtime ownership — either move it into the scan face (add to `MODULES` + `testImplementation`)
+or stand up a separately scoped adapter gate. This guard forces that decision rather than
+letting an adapter drift in unscanned.
+
+### NS gates added (all plain tests, NOT frozen ArchUnit rules)
+
+NS-1/NS-4/NS-6 are contracts a bytecode analyzer cannot express (source files on disk, the
+default wire-decode path, annotation/env defaults), so they are plain JUnit tests, not
+`FreezingArchRule`s. **No new frozen store entry exists and the committed `archunit_store/`
+is byte-for-byte unchanged.** Each lives in its owning module:
+
+- **NS-1** (`arch-test/NoProtoInProductionSourceTest`): no `*.proto` under any production
+  module's source. Module dirs come from Gradle's model (real `projectDir`); the scan covers
+  the union of the whole `<projectDir>/src` tree (catches an unregistered `src/main/proto/`)
+  and every registered main source-set root (catches a root placed outside `src`). Real
+  state: the sole wire-envelope proto lives at repo-top-level `proto/internal.proto`, outside
+  every module source, so the production scan is empty and the allowlist is empty.
+- **NS-4** (`rpc-client/DefaultCodecJsonTest`): JSON is the default wire codec, exercised on
+  the ACTUAL decode path. A DEFAULT (codec-unset) envelope parsed via `InputMarshaller.parse`
+  yields `InputProto.getEValue()==0`, and the exact server-dispatch resolver
+  `Serial.Instance.get(arg.getEValue())` (`UnaryMethod.java:183`, `DynamicInvoke.java:15`)
+  maps it to the JSON serial. The generated `getEValue()` + the resolver are the source of
+  truth (NOT `proto/internal.proto`, whose `e` field is commented out). Also pins the client
+  registration default `RpcClientFactory.globalSerialEnum == JSON`.
+- **NS-6** (`rpc-server-quarkus/McpDefaultOffContractTest`): the agent surface is opt-in —
+  `@UnsafeWeb.agentTool()` defaults `false`; and the MCP-enable flag defaults OFF as the
+  runtime observes it — the test reflects the runtime-retained
+  `@ConfigProperty(name="rpc.server.mcp.enabled", defaultValue="false")` on
+  `McpHandler.mcpEnabled` / `McpGetHandler.mcpEnabled` (so flipping the production
+  `defaultValue` to `"true"` turns it RED), keeps `enabled()` flip as a non-vacuity check,
+  and asserts `KRPC_MCP` unset resolves to `"false"`. Reading `@ConfigProperty` needs
+  MicroProfile Config on the test classpath, so `quarkus-arc` (already `compileOnly` for
+  main; `compileOnly` is not inherited by test) is added as `testImplementation` — reflection
+  only, no CDI container is booted (plain JUnit, not `@QuarkusTest`).
+
+### Store counts (unchanged)
+
+Frozen rule count stays at the v1 set (R1, R2 direction ×4, R2 completeness, R3, R4);
+per-rule frozen counts unchanged (R1 = 2 grandfathered cycles; all others = 0). The
+ARCH-002 / NS additions are plain tests and add zero store entries — the ADR-0005
+"adding a rule" store procedure was followed vacuously (nothing to write).
+
+### Evidence (ARCH-002, 2026-07-17, `docs/orchestration/ARCH-TEST-V2_IMPL_omp.md`)
+
+`gradle :arch-test:test :rpc-client:test :rpc-server-quarkus:test --rerun-tasks
+--max-workers=2` green: ArchitectureTest 8, ScopeGuardTest 6, ScanFaceCompletenessTest 3,
+NoProtoInProductionSourceTest 1, DefaultCodecJsonTest 3, McpDefaultOffContractTest 6
+(0 skipped). Scan-face self-proof (both include forms, real dummy dir): `include
+"rpc-phantom"` AND `include("rpc-phantom")` each turned it RED (2 failures each —
+`everyIncludedModuleIsConsciouslyClassified` via the Gradle model AND
+`everyOnDiskModuleDirectoryIsClassified` via the filesystem) — "not classified by
+arch-test: [rpc-phantom]"; removed → green. NS-1 self-proof: a seeded
+`rpc-api/src/main/proto/seed.proto` (an unregistered `proto/` dir) turned the gate RED —
+"Offenders: [rpc-api/src/main/proto/seed.proto]"; removed → green. Frozen store /
+`settings.gradle` / `archunit.properties` unchanged across every round.

--- a/docs/orchestration/ARCH-TEST-V2_IMPL_omp.md
+++ b/docs/orchestration/ARCH-TEST-V2_IMPL_omp.md
@@ -1,0 +1,173 @@
+# ARCH-TEST-V2 — scope-guard hardening + NS gate completion (impl findings, omp)
+
+Owner: omp. Worktree `/Users/martin/Garden/middleware/wt-arch002`, branch
+`feat/arch-test-v2` (cut from origin/dev @ 5e5b120). Reviewer: codex. Commits LOCAL.
+Date: 2026-07-17. **r1 review (`ARCH-TEST-V2_REVIEW_codex_r1.md`, REQUEST-CHANGES)
+incorporated — all 4 blocking + the advisory closed. r2 closure left one blocking (inventory
+task staleness); fixed below.**
+
+## Summary
+
+Hardened the `arch-test` gate against the "hardcoded scan-face silent miss" class
+(ARCH-002 absorb) and made NS-1 / NS-4 / NS-6 executable. **No production code changed.
+Zero new `FreezingArchRule`s — the committed `archunit_store/` and `archunit.properties`
+are byte-for-byte unchanged.** All four new guards are plain JUnit tests because the facts
+they check (the build's project graph, source files on disk, the default wire-decode path,
+annotation/env defaults) are not bytecode dependencies ArchUnit can see.
+
+## What changed (8 files)
+
+| File | Module | Purpose |
+|---|---|---|
+| `arch-test/build.gradle` | arch-test | `writeArchInventory` task emits Gradle's evaluated project model |
+| `arch-test/.../BuildInventory.java` | arch-test | reads that model (shared by both gates) |
+| `arch-test/.../ScanFaceCompletenessTest.java` | arch-test | ARCH-002 scan-face completeness |
+| `arch-test/.../NoProtoInProductionSourceTest.java` | arch-test | NS-1 no-proto-in-src |
+| `rpc-client/.../DefaultCodecJsonTest.java` | rpc-client | NS-4 JSON default codec (wire path) |
+| `rpc-server-quarkus/build.gradle` | rpc-server-quarkus | `quarkus-arc` testImplementation (for `@ConfigProperty`) |
+| `rpc-server-quarkus/.../McpDefaultOffContractTest.java` | rpc-server-quarkus | NS-6 flags default OFF |
+| `docs/decisions/ADR-0005-architecture-gates.md` | docs | ARCH-002 addendum |
+
+## r2 blocking finding — inventory task staleness (closed)
+
+**Finding:** `writeArchInventory` declared outputs but NO inputs, so Gradle marked it
+UP-TO-DATE and a stale `projects.tsv` survived an ordinary `:arch-test:test` (no
+`--rerun-tasks`) after a settings/source/dependency edit — recreating the scan-face false
+green on a normal run.
+
+**Fix (`arch-test/build.gradle`):**
+1. `writeArchInventory` is marked `outputs.upToDateWhen { false }` — it ALWAYS regenerates
+   the inventory (the evaluated model is recomputed every configuration; the task writes two
+   small files in a few ms). Simplest fully-staleness-proof choice; cheaper than enumerating
+   every model input dimension and risking a miss. **Tradeoff:** the task runs on every
+   build (negligible cost).
+2. `test` declares `inputs.files(writeArchInventory)`, so the test task re-runs whenever the
+   inventory CONTENT changes — i.e. whenever the project model changes — even on a plain
+   `:arch-test:test`. When nothing changed, content hashes match and test stays up-to-date
+   (no wasteful re-runs).
+
+Chain: model change → `writeArchInventory` always regenerates → `projects.tsv` content
+changes → `test` inputs change → `test` re-executes → RED. No stale snapshot possible.
+
+**Self-proof (reviewer's exact scenario, NO `--rerun-tasks`):**
+1. plain `:arch-test:test` → GREEN (ScanFace failures=0).
+2. add `include("rpc-phantom")` + dummy dir.
+3. plain `:arch-test:test` → **RED**, BUILD FAILED, ScanFace failures=2 — "not classified
+   by arch-test: [rpc-phantom]" (both the Gradle-model check and the filesystem check fire).
+4. revert → plain `:arch-test:test` → GREEN (failures=0).
+
+Frozen store / `archunit.properties` / `settings.gradle` unchanged across the sequence.
+
+## r1 blocking findings — how each was closed
+
+### #1 + #2 — settings.gradle parser bypass / module-discovery + custom projectDir
+
+Replaced the hand-rolled single-quoted, line-prefix parser (both tests) with Gradle's
+**authoritative evaluated project model**. `arch-test/build.gradle` adds a
+`writeArchInventory` task that emits, into `build/arch-inventory/`:
+
+- `projects.tsv` — one row per included subproject: `<gradlePath>\t<projectDir>\t<mainSrcDirs>`,
+  captured from `rootProject.allprojects` after `gradle.projectsEvaluated`.
+- `scanned-deps.txt` — arch-test's `testImplementation project(...)` paths (from the
+  dependency model).
+
+`BuildInventory` reads them. Because the set comes from Gradle itself, **every include form
+is covered** (`include 'x'`, `include "x"`, `include('x')`, multiline), plus intermediate
+projects (Gradle materializes `:examples`) and custom `projectDir`. Consequences:
+
+- **ScanFaceCompletenessTest** now classifies every project from the model, pins
+  `MODULES == testImplementation` deps, and adds a third filesystem-independent assertion:
+  every first-level `build.gradle`-bearing directory must be classified (a nested standalone
+  build with its own `settings.gradle`, e.g. `benchmark`, is skipped as not-a-subproject —
+  this was surfaced by the new check and handled honestly).
+- **NoProtoInProductionSourceTest** derives each production module's real `projectDir` from
+  the model and scans the UNION of the whole `<projectDir>/src` tree (catches an unregistered
+  `src/main/proto/x.proto`) and every registered main source-set root (catches a root placed
+  outside `src`). Custom `projectDir` is resolved via Gradle; a fully custom source root
+  *outside* `src` that Gradle doesn't report as a main source-set dir is the only residual
+  gap and is noted in the test. A production module with a non-existent `projectDir` is a hard
+  error, never treated as empty.
+- `EXCLUDED` gained `examples` (the aggregator project the model surfaces).
+
+### #3 — NS-6 never observed the production (`@ConfigProperty`) default
+
+The prior test read Java field defaults (always `false` without injection), so flipping the
+annotation `defaultValue` to `"true"` would have stayed green. Now `McpDefaultOffContractTest`
+reflects the runtime-retained `@ConfigProperty` on `McpHandler.mcpEnabled` /
+`McpGetHandler.mcpEnabled` and asserts `name=="rpc.server.mcp.enabled"` and
+`defaultValue=="false"` — this bites an annotation flip. The `enabled()` true-flip stays as a
+separate non-vacuity check; the OFF-branch and `KRPC_MCP`-unset checks remain (env-guarded).
+The `@UnsafeWeb.agentTool()` annotation-default assertion is kept.
+
+**Tradeoff (stated):** reading `@ConfigProperty` needs MicroProfile Config on the test
+classpath (`quarkus-arc` is `compileOnly` for main; `compileOnly` is not inherited by test),
+so it is added as `testImplementation`. This is reflection only — no CDI container is booted
+(plain JUnit, not `@QuarkusTest`). A full `@QuarkusTest` proving end-to-end injection was not
+added; the annotation-default reflection is the honest minimal bite.
+
+### #4 — NS-4 did not exercise the real default wire path
+
+Now `DefaultCodecJsonTest` parses a DEFAULT (codec-unset) envelope through the production
+`InputMarshaller.parse` → `InputProto.getEValue()==0`, then feeds that through the EXACT
+server-dispatch resolver `Serial.Instance.get(arg.getEValue())` (`UnaryMethod.java:183`,
+`invoke/DynamicInvoke.java:15`) and asserts the result is the JSON serial. So an
+envelope/generator change that makes an unset input select a non-JSON codec fails here — not
+just a change to `SerialEnum.JSON_VALUE`. Javadoc now cites the generated `getEValue()` and
+the dispatch resolver as the source of truth (the checked-in `proto/internal.proto` has its
+`e` field commented out and is NOT canonical for the runtime path). The client registration
+default (`RpcClientFactory.globalSerialEnum == JSON`) assertion is retained.
+
+### #5 (advisory) — Spring adapters outside R1–R4
+
+Added a policy-review trigger to the ADR-0005 addendum: the Spring adapters currently hold
+only autoconfig glue; before non-trivial runtime behavior is added to any adapter, revisit
+adapter runtime ownership (move into the scan face, or a separately scoped adapter gate). The
+scan-face `EXCLUDED` comment references it.
+
+## Freeze discipline
+
+Zero new `FreezingArchRule`s → `arch-test/archunit_store/` and `archunit.properties` are
+untouched (`git status -s` on both = empty across every probe round). The ADR-0005 store
+procedure was followed vacuously (nothing to write). Nothing was loosened.
+
+## Verification
+
+- `gradle :arch-test:test :rpc-client:test :rpc-server-quarkus:test --rerun-tasks
+  --max-workers=2` — BUILD SUCCESSFUL. Per-class, all `failures=0 errors=0 skipped=0`:
+  ArchitectureTest 8, ScopeGuardTest 6, ScanFaceCompletenessTest 3,
+  NoProtoInProductionSourceTest 1, DefaultCodecJsonTest 3, McpDefaultOffContractTest 6.
+  (NS-6 `skipped=0` ⇒ the env-guarded branches actually ran; `KRPC_MCP` unset here.)
+
+### Self-proofs (red/green)
+
+- **Scan-face, double-quoted:** `include "rpc-phantom"` (+ real dummy dir) → RED, **2
+  failures** (`everyIncludedModuleIsConsciouslyClassified` via the Gradle model AND
+  `everyOnDiskModuleDirectoryIsClassified` via the filesystem) — "not classified by
+  arch-test: [rpc-phantom]". Removed → green.
+- **Scan-face, parenthesized:** `include("rpc-phantom")` (+ real dummy dir) → RED, same 2
+  failures / message. Removed → green. (Both forms prove the Gradle-model parse; the old
+  text parser would have silently ignored both.)
+- **NS-1:** seeded `rpc-api/src/main/proto/seed.proto` (an unregistered `proto/` dir the
+  registered-source-set walk alone would miss) → RED — "Offenders:
+  [rpc-api/src/main/proto/seed.proto]". Removed → green.
+- Frozen store / `settings.gradle` / `archunit.properties` restored/unchanged after every
+  probe.
+
+## Boundaries touched
+
+- FOR/NOT-FOR: none crossed. arch-test remains test-only/unpublished. The `quarkus-arc`
+  addition to rpc-server-quarkus is `testImplementation` (no published-artifact impact); no
+  production source changed.
+- Source-of-truth: ADR-0005 gets an ARCH-002 addendum (no existing decision reversed; still
+  `accepted`). No roadmap/module-evolution status change needed.
+
+## Not validated / residual
+
+- Did NOT run the full root `gradle check` (ADR-0005: integration-heavy modules connect to
+  an internal MySQL host and can hang locally). Scoped module test tasks were run instead
+  (the ADR's recommended proof path).
+- NS-6 asserts the `@ConfigProperty` injection default via reflection, not an end-to-end
+  `@QuarkusTest` container boot (tradeoff stated in #3).
+- NS-1 residual gap: a production source root placed fully OUTSIDE `src` that Gradle does not
+  report as a main source-set dir would not be walked (none exist in this repo; noted in the
+  test).

--- a/docs/orchestration/ARCH-TEST-V2_REVIEW_codex_r1.md
+++ b/docs/orchestration/ARCH-TEST-V2_REVIEW_codex_r1.md
@@ -1,0 +1,163 @@
+# ARCH-TEST-V2 r1 — adversarial review
+
+Reviewed `8a11a7c` against `origin/dev`, cold context. Scope is the new `arch-test`
+plain gates, the two owning-module test files, and the ADR/implementation records. The
+contracts under review are: complete ArchUnit scan face, no service-author `.proto` in
+production source, JSON on the actual default wire path (NS-4), and MCP/agent exposure
+defaulting OFF (NS-6). Main risk: a check can pass while the controlled surface has moved
+outside the data it actually observes.
+
+## Findings
+
+### 1. `settings.gradle` parser silently ignores valid include forms
+
+- **Location:** `arch-test/src/test/java/tech/krpc/arch/ScanFaceCompletenessTest.java:85-95`
+- **Severity:** blocking
+- **Evidence:** `settingsIncludes()` only considers a physical line whose trimmed prefix is
+  `include` and extracts only single-quoted strings. Gradle accepts, among others,
+  `include "rpc-phantom"`, `include("rpc-phantom")`, and multiline invocations. Existing
+  single-quoted lines still supply `rpc-api`, so the sanity assertion remains green while a
+  newly included double-quoted module is absent from `includes`.
+- **Failure scenario:** add `include "rpc-phantom"`, give that module a production class
+  violating R1--R4, and do not add it to `MODULES`/`testImplementation`. Gradle includes and
+  builds it; this test never sees it and passes. The claimed anti-vacuous-green gate is then
+  bypassed. By contrast, the documented probe using `include 'rpc-phantom'` would fail as
+  claimed: lines 123-131 compute it as unclassified and name it in the failure message.
+  The explicit `EXCLUDED` set is not the problem—there is no broad `ext-*`/`*-spring`
+  regex that could swallow a new name.
+- **Suggested fix:** derive included project paths from Gradle's evaluated project model in a
+  build-level verification task, or feed that model to the test. If static parsing must
+  remain, implement and self-test a defined grammar covering single/double quotes,
+  parentheses, multiline calls, and comments; reject unsupported `include` syntax rather
+  than silently omitting it.
+
+### 2. NS-1 has the same module-discovery bypass and assumes default project directories
+
+- **Location:** `arch-test/src/test/java/tech/krpc/arch/NoProtoInProductionSourceTest.java:58-73, 83-88`
+- **Severity:** blocking
+- **Evidence:** `productionModules()` repeats the single-quoted, line-local parser. It then
+  maps a Gradle path to `repoRoot/<path-with-colons-replaced>` instead of using Gradle's
+  resolved `Project.projectDir` and production source-set directories.
+- **Failure scenario:** a new module is declared with `include("rpc-phantom")` (or is given
+  a custom `projectDir`), contains `src/main/proto/service.proto`, and is otherwise normal.
+  The test omits it (or looks in a non-existent default directory), so it passes with a
+  hand-authored production proto. The current walk does cover all files below a conventional
+  discovered module's `src/`, including `src/main/resources`; it is the discovery/path
+  assumption that leaves new/custom source sets outside the gate.
+- **Suggested fix:** share the authoritative Gradle project/source-set inventory used by the
+  build, then walk every production source directory for each included production project.
+  At minimum, fail when an include cannot be parsed or its expected project directory is
+  absent; do not treat it as an empty production module.
+
+### 3. MCP default-OFF test never observes Quarkus configuration injection
+
+- **Location:** `rpc-server-quarkus/src/test/java/tech/krpc/server/agent/McpDefaultOffContractTest.java:51-70`
+- **Severity:** blocking
+- **Evidence:** each test constructs a handler directly. Java initializes `boolean
+  mcpEnabled` to `false` independently of `@ConfigProperty`; no Quarkus/SmallRye injection
+  occurs. Changing both production annotations at `McpHandler.java:74` and
+  `McpGetHandler.java:35` from `defaultValue = "false"` to `defaultValue = "true"` leaves
+  these assertions green. The `h.mcpEnabled = true` flip only proves the `enabled()` branch,
+  not that an unconfigured runtime injects false.
+- **Failure scenario:** an operator starts an unconfigured Quarkus server after the annotation
+  default is changed to true. Both `/mcp` handlers are injected true and registered, while
+  this suite still reports default OFF.
+- **Suggested fix:** assert the runtime-retained `ConfigProperty.defaultValue()` on both
+  fields (no CDI container is needed), and preferably add a minimal configuration/integration
+  test proving an unconfigured container does not expose the route. Keep the true-flip as the
+  non-vacuity check.
+
+### 4. NS-4 test does not exercise the `InputProto` default wire path it claims to pin
+
+- **Location:** `rpc-client/src/test/java/tech/krpc/client/DefaultCodecJsonTest.java:34-46`
+- **Severity:** blocking
+- **Evidence:** the test only reads `SerialEnum.JSON_VALUE` and the registry mapping for the
+  literal `0`; it never creates/parses `InputProto` or feeds its unset codec value into the
+  decode path. Its Javadoc says `proto/internal.proto e=0`, but the checked-in
+  `proto/internal.proto:13-16` has no `e` field or `SerialEnum` (the field is commented out).
+  The generated Java used by production instead contains `getEValue()` and is consistent with
+  `proto/internal.java.proto:34-47`. Thus the test can stay green while the declared proto
+  source and the actual default-envelope path drift apart.
+- **Failure scenario:** an envelope/generator change makes an unset input select a different
+  codec path (or removes/relocates the codec field while preserving `SerialEnum.JSON_VALUE`
+  and `Serial.Instance.get(0)`). All three assertions remain green, but a default request no
+  longer demonstrably decodes as JSON.
+- **Suggested fix:** test `InputProto.getDefaultInstance()` (including serialize/parse) and
+  pass its codec value through the same resolver/reader used by server dispatch; assert the
+  result is JSON. Also resolve which top-level proto is canonical and make the test reference
+  that source of truth rather than the contradictory `proto/internal.proto` comment.
+
+### 5. Spring production adapters remain outside R1--R4
+
+- **Location:** `docs/decisions/ADR-0005-architecture-gates.md:246-253` and
+  `arch-test/src/test/java/tech/krpc/arch/ScanFaceCompletenessTest.java:59-76`
+- **Severity:** advisory
+- **Evidence:** original ADR-0005 explicitly limits ArchUnit ownership to the named six core
+  modules, so excluding `rpc-client-spring` and `rpc-server-spring` is not a hidden weakening
+  of that accepted decision. The addendum prominently names both adapters, explains the
+  Quarkus/Spring asymmetry, and the explicit list forces a conscious future decision. NS-1
+  still scans those adapters for proto files.
+- **Failure scenario:** a Spring adapter accumulates a core-layer, infrastructure, or
+  JDK-internal violation; R1--R4 do not observe it because it is intentionally out of scope.
+- **Suggested fix:** retain the explicit exclusion, but create/track a policy review trigger
+  for adapter runtime ownership (or add a separately scoped adapter gate) before more runtime
+  behavior is placed there.
+
+## Freeze, scope, and execution evidence
+
+- `git diff --exit-code origin/dev -- arch-test/archunit_store archunit.properties` exited
+  zero: frozen store and properties are unchanged.
+- The commit changes only `arch-test`, the two requested owning-module test paths, and docs;
+  no production source or existing rule/test was modified. `git diff --check` was clean.
+- `/opt/gradle/gradle/bin/gradle :arch-test:test --rerun-tasks --max-workers=2` —
+  `BUILD SUCCESSFUL`.
+- `/opt/gradle/gradle/bin/gradle :rpc-client:test :rpc-server-quarkus:test --rerun-tasks
+  --max-workers=2` — `BUILD SUCCESSFUL`.
+- The single-quoted scan-face self-proof is plausible from the implementation: a real
+  `include 'rpc-phantom'` reaches the unclassified-set assertion and fails with the module
+  name. A double-quoted dynamic probe was not obtained because a separate Gradle invocation
+  failed before configuration while loading `libnative-platform.dylib`; the bypass follows
+  directly from the parser and does not depend on that failed invocation. The temporary
+  settings edit and directory were restored; no implementation-file residue remains.
+
+## Verdict
+
+**REQUEST-CHANGES** — multiple claimed guard classes can be bypassed or pass without
+observing their stated runtime/wire contract, so the required anti-vacuity guarantee is not
+yet established.
+
+## r2 closure
+
+Reviewed closure commit `0d0d2e4` only against the r1 findings.
+
+- **r1 #1 / #2 (Gradle include and real source locations): partially closed, but still
+  blocking.** `BuildInventory` now consumes Gradle's evaluated project model, records real
+  `projectDir` plus main source roots, and `NoProtoInProductionSourceTest` walks both those
+  roots and `<projectDir>/src`. `BuildInventory` fails loudly when its property, directory,
+  or either inventory file is missing; `:arch-test:test` declares a dependency on the writer.
+  However, `writeArchInventory` declares only outputs
+  (`arch-test/build.gradle:52-61`) and no inputs representing `settings.gradle`, project
+  paths/directories/source sets, or `testImplementation` project dependencies. After the
+  requested rerun generated the TSV, a normal
+  `gradle :arch-test:writeArchInventory --info --max-workers=2` reported the task
+  **UP-TO-DATE**. Editing `settings.gradle` (or a project build script that changes a source
+  set) can therefore leave the old TSV in place; a normal `:arch-test:test` can consume it
+  and miss a new project—the original vacuous-green class. Declare the evaluated inventory
+  content as a task input (and/or all contributing settings/build files) so a model change
+  forces regeneration, then self-prove a non-`--rerun-tasks` include edit goes red.
+- **r1 #3 (NS-6): closed.** Both handler fields are now reflected as runtime-retained
+  `@ConfigProperty`, checking flag name and `defaultValue == "false"`; an annotation flip
+  is observable. The explicit true flip still proves the gate branch.
+- **r1 #4 (NS-4): closed.** The test parses an empty wire envelope via
+  `InputMarshaller.parse`, asserts its decoded `getEValue()`, and feeds that value through
+  the same `Serial.Instance.get(arg.getEValue())` resolver used by dispatch.
+- **r1 #5 (Spring scope): closed as advisory.** ADR-0005 now contains the requested policy
+  review trigger before adapter runtime behavior grows.
+- **Freeze discipline:** `git diff --exit-code origin/dev -- arch-test/archunit_store
+  archunit.properties` exited zero.
+- **Execution:** `/opt/gradle/gradle/bin/gradle :arch-test:test :rpc-client:test
+  :rpc-server-quarkus:test --rerun-tasks --max-workers=2` completed `BUILD SUCCESSFUL`.
+
+**REQUEST-CHANGES** — the evaluated-model design is correct when regenerated, but its writer
+is allowed to go stale during an ordinary test invocation, recreating the scan-face false
+green that r1 required the gate to eliminate.

--- a/rpc-client/src/test/java/tech/krpc/client/DefaultCodecJsonTest.java
+++ b/rpc-client/src/test/java/tech/krpc/client/DefaultCodecJsonTest.java
@@ -1,0 +1,75 @@
+package tech.krpc.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.io.ByteArrayInputStream;
+import java.lang.reflect.Field;
+import tech.krpc.common.proto.InputMarshaller;
+import tech.krpc.internal.InputProto;
+import tech.krpc.internal.SerialEnum;
+import tech.krpc.serial.Serial;
+import org.junit.jupiter.api.Test;
+
+/**
+ * NS-4 — JSON is the default wire codec, exercised on the ACTUAL decode/dispatch path.
+ *
+ * <p>The umbrella NORTH_STAR NS-4 makes JSON the default serialization (SPEC §2). The wire
+ * envelope's codec is {@code InputProto} field {@code e} (proto3 enum, field number 1): an
+ * inbound request that does not set it decodes to {@code getEValue()==0}. Production server
+ * dispatch resolves the codec by exactly {@code Serial.Instance.get(arg.getEValue())} —
+ * see {@code rpc-server/.../UnaryMethod.java:183} and
+ * {@code rpc-server/.../invoke/DynamicInvoke.java:15} — and {@code InputMarshaller.stream}
+ * treats {@code getEValue()==0} as JSON ({@code rpc-common/.../common/proto/InputMarshaller.java:33}).
+ *
+ * <p>This test drives the REAL classes production runs: it parses a DEFAULT (empty / codec
+ * unset) wire envelope through {@link InputMarshaller#parse} and passes the decoded codec
+ * value through the SAME {@code Serial.Instance.get(...)} resolver, asserting JSON. So an
+ * envelope/generator change that makes an unset input select a non-JSON codec fails here,
+ * not just a change to the {@code SerialEnum} constant. (Source of truth is the generated
+ * {@link InputProto#getEValue()} and the dispatch resolver, NOT {@code proto/internal.proto}
+ * whose {@code e} field is commented out.)
+ *
+ * <p>Plain JUnit test (owning module: rpc-client, the client registration layer, which also
+ * verifies the client registration default). NS-4 is a value / wire-path contract, not a
+ * bytecode dependency, so it is not an ArchUnit frozen rule.
+ */
+class DefaultCodecJsonTest {
+
+    @Test
+    void defaultWireEnvelopeDecodesToJsonCodec() throws Exception {
+        // A DEFAULT inbound envelope = no bytes set (codec field e unset). Parse it exactly as
+        // gRPC server dispatch does (InputMarshaller.parse -> new InputProto(InputStream)).
+        InputProto defaultInput =
+            new InputMarshaller().parse(new ByteArrayInputStream(new byte[0]));
+
+        // proto3 default: an unset codec field is numeric 0 on the wire.
+        assertEquals(0, defaultInput.getEValue(),
+            "an unset codec field on the wire must decode to 0 (proto3 default)");
+
+        // The EXACT resolver server dispatch uses (Serial.Instance.get(arg.getEValue()))
+        // must map that default to the JSON serial.
+        assertSame(SerialEnum.JSON, Serial.Instance.get(defaultInput.getEValue()).id(),
+            "the default wire codec (unset e -> 0) must resolve to JSON on the dispatch path");
+    }
+
+    @Test
+    void serialEnumJsonIsOrdinalZero() {
+        // Pin the invariant the decode path relies on: JSON is the ordinal-0 codec, so the
+        // proto3 default and the resolver key line up.
+        assertEquals(0, SerialEnum.JSON_VALUE, "JSON must be the ordinal-0 (proto3 default) codec");
+        assertSame(SerialEnum.JSON, Serial.Instance.get(SerialEnum.JSON_VALUE).id(),
+            "codec resolver for SerialEnum.JSON must be the JSON serial");
+    }
+
+    @Test
+    void clientRegistrationDefaultIsJson() throws ReflectiveOperationException {
+        // RpcClientFactory.globalSerialEnum is the default codec a client picks when none is
+        // set (getDefaultSerial() falls back to it). It must be JSON. Read reflectively: the
+        // field is private with no public getter, and this asserts the durable default.
+        Field global = RpcClientFactory.class.getDeclaredField("globalSerialEnum");
+        global.setAccessible(true);
+        assertSame(SerialEnum.JSON, global.get(null),
+            "RpcClientFactory.globalSerialEnum (client registration default codec) must be JSON");
+    }
+}

--- a/rpc-server-quarkus/build.gradle
+++ b/rpc-server-quarkus/build.gradle
@@ -33,6 +33,11 @@ dependencies {
     testRuntimeOnly "org.junit.platform:junit-platform-launcher"
     testImplementation "io.grpc:grpc-stub:${grpcVersion}"
     testImplementation "io.netty:netty-codec-http:$nettyGrpcVersion"
+    // NS-6 default-OFF contract test reflects on @ConfigProperty (MicroProfile Config, via
+    // quarkus-arc) to assert defaultValue=="false" on the mcp-enable flags. quarkus-arc is
+    // compileOnly for main and compileOnly is NOT inherited by test; this is reflection only
+    // (no CDI container is booted — the tests are plain JUnit, not @QuarkusTest).
+    testImplementation "io.quarkus:quarkus-arc:$quarkusMiniSupport"
 
 
 //    implementation platform("io.quarkus:quarkus-bom:${quarkusPlatformVersion}")
@@ -62,4 +67,3 @@ compileTestJava {
 test {
     useJUnitPlatform()
 }
-

--- a/rpc-server-quarkus/src/test/java/tech/krpc/server/agent/McpDefaultOffContractTest.java
+++ b/rpc-server-quarkus/src/test/java/tech/krpc/server/agent/McpDefaultOffContractTest.java
@@ -1,0 +1,109 @@
+package tech.krpc.server.agent;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.lang.reflect.Field;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import tech.krpc.annotation.UnsafeWeb;
+import tech.krpc.util.EnvUtils;
+import org.junit.jupiter.api.Test;
+
+/**
+ * NS-6 — the agent surface is opt-in; its flags default OFF.
+ *
+ * <p>The umbrella NORTH_STAR NS-6 requires the agent/MCP surface to be opt-in with flags
+ * defaulting OFF (ADR-0004 AGENT-001: "byte-level zero new surface" until enabled). This
+ * test pins the PRODUCTION defaults (the values an unconfigured runtime observes), not Java
+ * field defaults:
+ *
+ * <ul>
+ *   <li>{@code @UnsafeWeb.agentTool()} defaults {@code false} (annotation default) — web
+ *       exposure never implies MCP-tool exposure.</li>
+ *   <li>{@link McpHandler}/{@link McpGetHandler} {@code mcpEnabled} carries
+ *       {@code @ConfigProperty(name="rpc.server.mcp.enabled", defaultValue="false")}: an
+ *       unconfigured Quarkus/SmallRye injection yields {@code false}. Asserted via
+ *       reflection on the runtime-retained annotation (no CDI container needed), so flipping
+ *       the production {@code defaultValue} to {@code "true"} turns this RED.</li>
+ *   <li>{@code KRPC_MCP} unset resolves to {@code "false"} (OFF) at the env layer.</li>
+ * </ul>
+ *
+ * <p>Tradeoff: this asserts the {@code @ConfigProperty.defaultValue()} (the injection
+ * default) rather than booting a container to observe injection end-to-end — the minimal
+ * honest bite without a {@code @QuarkusTest}. The {@code enabled()} true-flip and OFF-branch
+ * checks remain as non-vacuity. Plain JUnit test in {@code tech.krpc.server.agent} (the
+ * {@code mcpEnabled} fields are package-private); this is the module that owns and ENFORCES
+ * the MCP flag gate.
+ */
+class McpDefaultOffContractTest {
+
+    /** True only if the ambient {@code KRPC_MCP} is explicitly turned on (a branch test would be moot). */
+    private static boolean krpcMcpEnvIsOn() {
+        String e = System.getenv("KRPC_MCP");
+        return e != null && ("true".equalsIgnoreCase(e) || "1".equals(e));
+    }
+
+    private static ConfigProperty mcpEnabledConfig(Class<?> handler) throws NoSuchFieldException {
+        Field f = handler.getDeclaredField("mcpEnabled");
+        ConfigProperty cp = f.getAnnotation(ConfigProperty.class);
+        assertNotNull(cp, handler.getSimpleName() + ".mcpEnabled must carry @ConfigProperty");
+        return cp;
+    }
+
+    @Test
+    void agentToolDefaultsFalse() throws NoSuchMethodException {
+        Object dflt = UnsafeWeb.class.getMethod("agentTool").getDefaultValue();
+        assertEquals(Boolean.FALSE, dflt,
+            "@UnsafeWeb.agentTool() must default false — MCP-tool exposure is opt-in, never"
+            + " implied by @UnsafeWeb (web exposure) alone (NS-6 / ADR-0004).");
+    }
+
+    @Test
+    void mcpPostHandlerConfigDefaultsOff() throws NoSuchFieldException {
+        ConfigProperty cp = mcpEnabledConfig(McpHandler.class);
+        assertEquals("rpc.server.mcp.enabled", cp.name(), "POST /mcp flag name");
+        assertEquals("false", cp.defaultValue(),
+            "rpc.server.mcp.enabled must default \"false\" — an unconfigured runtime injects OFF (POST /mcp)");
+    }
+
+    @Test
+    void mcpGetHandlerConfigDefaultsOff() throws NoSuchFieldException {
+        ConfigProperty cp = mcpEnabledConfig(McpGetHandler.class);
+        assertEquals("rpc.server.mcp.enabled", cp.name(), "GET /mcp flag name");
+        assertEquals("false", cp.defaultValue(),
+            "rpc.server.mcp.enabled must default \"false\" — an unconfigured runtime injects OFF (GET /mcp)");
+    }
+
+    @Test
+    void mcpPostHandlerGateFlips() {
+        McpHandler h = new McpHandler();
+        // Non-vacuity: the flag actually gates enabled() — flip it on and the route enables.
+        h.mcpEnabled = true;
+        assertTrue(h.enabled(), "rpc.server.mcp.enabled=true must enable POST /mcp");
+        // OFF branch: flag false + KRPC_MCP not on -> disabled (route never registered).
+        assumeTrue(!krpcMcpEnvIsOn(), "KRPC_MCP is turned on in this env; OFF-branch check is moot");
+        h.mcpEnabled = false;
+        assertFalse(h.enabled(), "POST /mcp must be OFF when the flag and KRPC_MCP are off");
+    }
+
+    @Test
+    void mcpGetHandlerGateFlips() {
+        McpGetHandler h = new McpGetHandler();
+        h.mcpEnabled = true;
+        assertTrue(h.enabled(), "rpc.server.mcp.enabled=true must enable GET /mcp");
+        assumeTrue(!krpcMcpEnvIsOn(), "KRPC_MCP is turned on in this env; OFF-branch check is moot");
+        h.mcpEnabled = false;
+        assertFalse(h.enabled(), "GET /mcp must be OFF when the flag and KRPC_MCP are off");
+    }
+
+    @Test
+    void krpcMcpEnvDefaultsOff() {
+        assumeTrue(System.getenv("KRPC_MCP") == null,
+            "KRPC_MCP is set in this env; the unset-default assertion is moot");
+        assertEquals("false", EnvUtils.env("KRPC_MCP", "false"),
+            "KRPC_MCP unset must resolve to \"false\" (agent surface OFF by default)");
+    }
+}


### PR DESCRIPTION
## ARCH-TEST-V2 — anti-vacuity gates on top of the #22 ratchet

Four gates as plain tests (deliberately zero new FreezingArchRules — these facts are invisible to bytecode analysis; `archunit_store/` + `archunit.properties` byte-for-byte unchanged):

- **Scan-face completeness guard** (absorbs consumer ARCH-002 pattern): compares Gradle's own **evaluated project model** (a `writeArchInventory` task emits projects.tsv + scanned-deps.txt; `upToDateWhen{false}` + `test.inputs.files(...)` make stale snapshots impossible on plain runs) against arch-test's scanned set. A new core module not added to arch-test turns RED naming the module. Spring adapter exclusion is explicit + documented with a policy-review trigger in the ADR-0005 addendum.
- **NS-1**: no `.proto` under any production module's source trees (wire envelope lives at top-level `proto/`, outside module src — empty allowlist).
- **NS-4**: default wire codec is JSON, asserted through the REAL decode path (`InputMarshaller.parse` on an empty envelope → `Serial.Instance.get(getEValue())`), not an enum mapping.
- **NS-6**: agent surface opt-in — `@UnsafeWeb.agentTool()` annotation default false; `rpc.server.mcp.enabled`/`KRPC_MCP` default OFF asserted via the runtime-retained `@ConfigProperty` annotation (an annotation flip to "true" turns it red), plus the `enabled()` branch non-vacuity check.

## Verification
- Red/green self-proofs captured per gate, including the reviewer-reproduced plain-run sequence (no `--rerun-tasks`): green → `include("rpc-phantom")` → RED (failures=2) → revert → green. Fake includes tested in single-quoted, double-quoted, and parenthesized forms.
- `:arch-test:test :rpc-client:test :rpc-server-quarkus:test` green; freeze store diff vs dev empty.
- Adversarial review: codex, 3 rounds (r1: 4 blocking vacuous-green findings; r2: stale-inventory UP-TO-DATE hole; r3 APPROVE with independent probe reproduction).